### PR TITLE
Fix error handling for invalid pods

### DIFF
--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -7,18 +7,27 @@ This implementation provides a way to dynamically spin up jobs to run container 
 Some things are expected to be set when using these hooks
 - The runner itself should be running in a pod, with a service account with the following permissions
 ```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: runner-role
+rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "create", "delete"]
 - apiGroups: [""]
   resources: ["pods/exec"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "create"]
 - apiGroups: [""]
   resources: ["pods/log"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "watch",]
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "delete"]
 ```
 - The `ACTIONS_RUNNER_POD_NAME` env should be set to the name of the pod
 - The `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER` env should be set to true to prevent the runner from running any jobs outside of a container

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -43,7 +43,7 @@ async function run(): Promise<void> {
         throw new Error(`Command not recognized: ${command}`)
     }
   } catch (error) {
-    core.error(JSON.stringify(error))
+    core.error(error as Error)
     exitCode = 1
   }
   process.exitCode = exitCode

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -311,7 +311,7 @@ export async function waitForPodPhases(
   podName: string,
   awaitingPhases: Set<PodPhase>,
   backOffPhases: Set<PodPhase>,
-  maxTimeSeconds = 45 * 60 // 45 min
+  maxTimeSeconds = 10 * 60 // 10 min
 ): Promise<void> {
   const backOffManager = new BackOffManager(maxTimeSeconds)
   let phase: PodPhase = PodPhase.UNKNOWN


### PR DESCRIPTION
This pr has a few changes for k8s hooks:
- Currently, we wait 45 minutes to assign pods, this is a little high, the pr bumps it down to 10, otherwise we fail the job.
- Updates the readme to have a more complete set of permissions needed for k8s hooks 
- We were failing to output the error (JSON.stringify on an error does not work), so this pr makes sure to throw a proper error message on failure.