### PR TITLE
Make K8s claim name optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "hooks",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -32,7 +32,7 @@ rules:
 - The `ACTIONS_RUNNER_POD_NAME` env should be set to the name of the pod
 - The `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER` env should be set to true to prevent the runner from running any jobs outside of a container
 - The runner pod should map a persistent volume claim into the `_work` directory
-    - The `ACTIONS_RUNNER_CLAIM_NAME` env should be set to the persistent volume claim that contains the runner's working directory
+    - The `ACTIONS_RUNNER_CLAIM_NAME` env should be set to the persistent volume claim that contains the runner's working directory, otherwise it defaults to `${ACTIONS_RUNNER_POD_NAME}-work`
 - Some actions runner env's are expected to be set. These are set automatically by the runner.
     - `RUNNER_WORKSPACE` is expected to be set to the workspace of the runner
     - `GITHUB_WORKSPACE` is expected to be set to the workspace of the job

--- a/packages/k8s/src/hooks/constants.ts
+++ b/packages/k8s/src/hooks/constants.ts
@@ -27,7 +27,7 @@ export function getStepPodName(): string {
 export function getVolumeClaimName(): string {
   const name = process.env.ACTIONS_RUNNER_CLAIM_NAME
   if (!name) {
-    return `${getRunnerPodName}-work`
+    return `${getRunnerPodName()}-work`
   }
   return name
 }

--- a/packages/k8s/src/hooks/constants.ts
+++ b/packages/k8s/src/hooks/constants.ts
@@ -27,9 +27,7 @@ export function getStepPodName(): string {
 export function getVolumeClaimName(): string {
   const name = process.env.ACTIONS_RUNNER_CLAIM_NAME
   if (!name) {
-    throw new Error(
-      "'ACTIONS_RUNNER_CLAIM_NAME' is required, please contact your self hosted runner administrator"
-    )
+    return `${getRunnerPodName}-work`
   }
   return name
 }

--- a/packages/k8s/tests/test-setup.ts
+++ b/packages/k8s/tests/test-setup.ts
@@ -21,7 +21,6 @@ export class TestHelper {
 
   public async initialize(): Promise<void> {
     process.env['ACTIONS_RUNNER_POD_NAME'] = `${this.podName}`
-    process.env['ACTIONS_RUNNER_CLAIM_NAME'] = `${this.podName}-work`
     process.env['RUNNER_WORKSPACE'] = `${this.tempDirPath}/_work/repo`
     process.env['RUNNER_TEMP'] = `${this.tempDirPath}/_work/_temp`
     process.env['GITHUB_WORKSPACE'] = `${this.tempDirPath}/_work/repo/repo`

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -1,5 +1,5 @@
 ## Features
-- Initial Release
+- Loosened the restriction on `ACTIONS_RUNNER_CLAIM_NAME` to be optional, not required for k8s hooks
 
 ## Bugs
 


### PR DESCRIPTION
This pr loosens the restriction on the runner claim name, letting it fallback to the pod name -work rather then failing if it is not set. This is helpful in cases where pod names are generated automatically, and the [downward api ](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)doesn't give appropriate flexibility to set this env.