### PR TITLE
Don't use JSON.stringify for errors

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -49,7 +49,7 @@ export async function prepareJob(
     createdPod = await createPod(container, services, args.registry)
   } catch (err) {
     await prunePods()
-    throw new Error(`failed to create job pod: ${JSON.stringify(err)}`)
+    throw new Error(`failed to create job pod: ${err}`)
   }
 
   if (!createdPod?.metadata?.name) {

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -28,7 +28,7 @@ export async function runScriptStep(
       JOB_CONTAINER_NAME
     )
   } catch (err) {
-    throw new Error(`failed to run script step: ${JSON.stringify(err)}`)
+    throw new Error(`failed to run script step: ${err}`)
   } finally {
     fs.rmSync(runnerPath)
   }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -22,7 +22,7 @@ async function run(): Promise<void> {
       throw new Error(
         `The Service account needs the following permissions ${JSON.stringify(
           requiredPermissions
-        )} on the pod resource in the '${namespace}' namespace. Please contact your self hosted runner administrator.`
+        )} on the pod resource in the '${namespace()}' namespace. Please contact your self hosted runner administrator.`
       )
     }
     switch (command) {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -210,7 +210,7 @@ export async function execPodStep(
         }
       )
     } catch (error) {
-      reject(JSON.stringify(error))
+      reject(error)
     }
   })
 }
@@ -372,7 +372,7 @@ export async function getPodLogs(
   })
 
   logStream.on('error', err => {
-    process.stderr.write(JSON.stringify(err))
+    process.stderr.write(err.message)
   })
 
   const r = await log.log(namespace(), podName, containerName, logStream, {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -185,33 +185,29 @@ export async function execPodStep(
 ): Promise<void> {
   const exec = new k8s.Exec(kc)
   await new Promise(async function (resolve, reject) {
-    try {
-      await exec.exec(
-        namespace(),
-        podName,
-        containerName,
-        command,
-        process.stdout,
-        process.stderr,
-        stdin ?? null,
-        false /* tty */,
-        resp => {
-          // kube.exec returns an error if exit code is not 0, but we can't actually get the exit code
-          if (resp.status === 'Success') {
-            resolve(resp.code)
-          } else {
-            reject(
-              JSON.stringify({
-                message: resp?.message,
-                details: resp?.details
-              })
-            )
-          }
+    await exec.exec(
+      namespace(),
+      podName,
+      containerName,
+      command,
+      process.stdout,
+      process.stderr,
+      stdin ?? null,
+      false /* tty */,
+      resp => {
+        // kube.exec returns an error if exit code is not 0, but we can't actually get the exit code
+        if (resp.status === 'Success') {
+          resolve(resp.code)
+        } else {
+          reject(
+            JSON.stringify({
+              message: resp?.message,
+              details: resp?.details
+            })
+          )
         }
-      )
-    } catch (error) {
-      reject(error)
-    }
+      }
+    )
   })
 }
 

--- a/packages/k8s/tests/test-setup.ts
+++ b/packages/k8s/tests/test-setup.ts
@@ -40,7 +40,7 @@ export class TestHelper {
       await this.createTestVolume()
       await this.createTestJobPod()
     } catch (e) {
-      console.log(JSON.stringify(e))
+      console.log(e)
     }
   }
 


### PR DESCRIPTION
`JSON.stringify` hides errors, so lets remove those invocations and replace them with just printing the error