### PR TITLE
exposing env variables from runner with `DOCKER_` prefix to respect docker options set on host

### DIFF
--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -427,6 +427,9 @@ export async function containerRun(
   dockerArgs.push(args.image)
   if (args.entryPointArgs) {
     for (const entryPointArg of args.entryPointArgs) {
+      if (!entryPointArg) {
+        continue
+      }
       dockerArgs.push(entryPointArg)
     }
   }

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -16,12 +16,41 @@ export async function runDockerCommand(
   args: string[],
   options?: RunDockerCommandOptions
 ): Promise<string> {
+  options = optionsWithDockerEnvs(options)
   const pipes = await exec.getExecOutput('docker', args, options)
   if (pipes.exitCode !== 0) {
     core.error(`Docker failed with exit code ${pipes.exitCode}`)
     return Promise.reject(pipes.stderr)
   }
   return Promise.resolve(pipes.stdout)
+}
+
+export function optionsWithDockerEnvs(
+  options?: RunDockerCommandOptions
+): RunDockerCommandOptions | undefined {
+  const dockerEnvs = {}
+  for (const e in process.env) {
+    if (e.startsWith('DOCKER_')) {
+      dockerEnvs[e] = process.env[e]
+    }
+  }
+  if (Object.keys(dockerEnvs).length === 0) {
+    return
+  }
+
+  const newOptions = {
+    workingDir: options?.workingDir,
+    input: options?.input,
+    env: options?.env || {}
+  }
+
+  for (const [key, value] of Object.entries(dockerEnvs)) {
+    if (!newOptions.env[key]) {
+      newOptions.env[key] = value as string
+    }
+  }
+
+  return newOptions
 }
 
 export function sanitize(val: string): string {

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -28,14 +28,26 @@ export async function runDockerCommand(
 export function optionsWithDockerEnvs(
   options?: RunDockerCommandOptions
 ): RunDockerCommandOptions | undefined {
+  // From https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+  const dockerCliEnvs = new Set([
+    'DOCKER_API_VERSION',
+    'DOCKER_CERT_PATH',
+    'DOCKER_CONFIG',
+    'DOCKER_CONTENT_TRUST_SERVER',
+    'DOCKER_CONTENT_TRUST',
+    'DOCKER_CONTEXT',
+    'DOCKER_DEFAULT_PLATFORM',
+    'DOCKER_HIDE_LEGACY_COMMANDS',
+    'DOCKER_HOST',
+    'DOCKER_STACK_ORCHESTRATOR',
+    'DOCKER_TLS_VERIFY',
+    'BUILDKIT_PROGRESS'
+  ])
   const dockerEnvs = {}
-  for (const e in process.env) {
-    if (e.startsWith('DOCKER_')) {
-      dockerEnvs[e] = process.env[e]
+  for (const key in process.env) {
+    if (dockerCliEnvs.has(key)) {
+      dockerEnvs[key] = process.env[key]
     }
-  }
-  if (Object.keys(dockerEnvs).length === 0) {
-    return
   }
 
   const newOptions = {
@@ -44,10 +56,9 @@ export function optionsWithDockerEnvs(
     env: options?.env || {}
   }
 
+  // Set docker envs or overwrite provided ones
   for (const [key, value] of Object.entries(dockerEnvs)) {
-    if (!newOptions.env[key]) {
-      newOptions.env[key] = value as string
-    }
+    newOptions.env[key] = value as string
   }
 
   return newOptions

--- a/packages/docker/tests/utils-test.ts
+++ b/packages/docker/tests/utils-test.ts
@@ -1,4 +1,4 @@
-import { sanitize } from '../src/utils'
+import { optionsWithDockerEnvs, sanitize } from '../src/utils'
 
 describe('Utilities', () => {
   it('should return sanitized image name', () => {
@@ -8,5 +8,52 @@ describe('Utilities', () => {
   it('should return the same string', () => {
     const validStr = 'teststr8_one'
     expect(sanitize(validStr)).toBe(validStr)
+  })
+
+  describe('with docker options', () => {
+    it('should augment options with docker environment variables', () => {
+      process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
+      process.env.DOCKER_NOTEXIST = 'notexist'
+
+      const optionDefinitions = [undefined, {}, { env: {} }]
+      for (const opt of optionDefinitions) {
+        let options = optionsWithDockerEnvs(opt)
+        expect(options).toBeDefined()
+        expect(options?.env).toBeDefined()
+        expect(options?.env?.DOCKER_HOST).toBe(process.env.DOCKER_HOST)
+        expect(options?.env?.DOCKER_NOTEXIST).toBe(process.env.DOCKER_NOTEXIST)
+      }
+    })
+
+    it('should not overwrite provided docker option', () => {
+      process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
+      process.env.DOCKER_NOTEXIST = 'notexist'
+      const expectedDockerHost = 'unix://var/run/docker.sock'
+      const opt = {
+        env: {
+          DOCKER_HOST: expectedDockerHost
+        }
+      }
+
+      const options = optionsWithDockerEnvs(opt)
+      expect(options).toBeDefined()
+      expect(options?.env).toBeDefined()
+      expect(options?.env?.DOCKER_HOST).toBe(expectedDockerHost)
+      expect(options?.env?.DOCKER_NOTEXIST).toBe(process.env.DOCKER_NOTEXIST)
+    })
+
+    it('should not overwrite other options', () => {
+      process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
+      process.env.DOCKER_NOTEXIST = 'notexist'
+      const opt = {
+        workingDir: 'test',
+        input: Buffer.from('test')
+      }
+
+      const options = optionsWithDockerEnvs(opt)
+      expect(options).toBeDefined()
+      expect(options?.workingDir).toBe(opt.workingDir)
+      expect(options?.input).toBe(opt.input)
+    })
   })
 })

--- a/packages/docker/tests/utils-test.ts
+++ b/packages/docker/tests/utils-test.ts
@@ -41,7 +41,9 @@ describe('Utilities', () => {
       expect(options).toBeDefined()
       expect(options?.workingDir).toBe(opt.workingDir)
       expect(options?.input).toBe(opt.input)
-      expect(options?.env).toStrictEqual({ DOCKER_HOST: process.env.DOCKER_HOST })
+      expect(options?.env).toStrictEqual({
+        DOCKER_HOST: process.env.DOCKER_HOST
+      })
     })
   })
 })

--- a/packages/docker/tests/utils-test.ts
+++ b/packages/docker/tests/utils-test.ts
@@ -15,36 +15,23 @@ describe('Utilities', () => {
       process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
       process.env.DOCKER_NOTEXIST = 'notexist'
 
-      const optionDefinitions = [undefined, {}, { env: {} }]
+      const optionDefinitions: any = [
+        undefined,
+        {},
+        { env: {} },
+        { env: { DOCKER_HOST: 'unix://var/run/docker.sock' } }
+      ]
       for (const opt of optionDefinitions) {
         let options = optionsWithDockerEnvs(opt)
         expect(options).toBeDefined()
         expect(options?.env).toBeDefined()
         expect(options?.env?.DOCKER_HOST).toBe(process.env.DOCKER_HOST)
-        expect(options?.env?.DOCKER_NOTEXIST).toBe(process.env.DOCKER_NOTEXIST)
+        expect(options?.env?.DOCKER_NOTEXIST).toBeUndefined()
       }
-    })
-
-    it('should not overwrite provided docker option', () => {
-      process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
-      process.env.DOCKER_NOTEXIST = 'notexist'
-      const expectedDockerHost = 'unix://var/run/docker.sock'
-      const opt = {
-        env: {
-          DOCKER_HOST: expectedDockerHost
-        }
-      }
-
-      const options = optionsWithDockerEnvs(opt)
-      expect(options).toBeDefined()
-      expect(options?.env).toBeDefined()
-      expect(options?.env?.DOCKER_HOST).toBe(expectedDockerHost)
-      expect(options?.env?.DOCKER_NOTEXIST).toBe(process.env.DOCKER_NOTEXIST)
     })
 
     it('should not overwrite other options', () => {
       process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
-      process.env.DOCKER_NOTEXIST = 'notexist'
       const opt = {
         workingDir: 'test',
         input: Buffer.from('test')
@@ -54,6 +41,7 @@ describe('Utilities', () => {
       expect(options).toBeDefined()
       expect(options?.workingDir).toBe(opt.workingDir)
       expect(options?.input).toBe(opt.input)
+      expect(options?.env).toStrictEqual({ DOCKER_HOST: process.env.DOCKER_HOST })
     })
   })
 })


### PR DESCRIPTION
Fixes #39 
