### PR TITLE
k8s: don't overwriting service entrypoint

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -158,7 +158,7 @@ function createPodSpec(
   name: string,
   jobContainer = false
 ): k8s.V1Container {
-  if (!container.entryPoint) {
+  if (!container.entryPoint && jobContainer) {
     container.entryPoint = DEFAULT_CONTAINER_ENTRY_POINT
     container.entryPointArgs = DEFAULT_CONTAINER_ENTRY_POINT_ARGS
   }


### PR DESCRIPTION
Closes #44

This change does not overwrite entrypoint if when createPodSpec is not executed for a jobContainer.

This is created as a draft to revisit if we can incorporate `--entrypoint` overwrite 