### PR TITLE
docker and k8s: read from stdin inside try catch block

### DIFF
--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -16,15 +16,14 @@ import {
 import { checkEnvironment } from './utils'
 
 async function run(): Promise<void> {
-  const input = await getInputFromStdin()
-
-  const args = input['args']
-  const command = input['command']
-  const responseFile = input['responseFile']
-  const state = input['state']
-
   try {
     checkEnvironment()
+    const input = await getInputFromStdin()
+
+    const args = input['args']
+    const command = input['command']
+    const responseFile = input['responseFile']
+    const state = input['state']
     switch (command) {
       case Command.PrepareJob:
         await prepareJob(args as PrepareJobArgs, responseFile)

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -9,15 +9,14 @@ import {
 import { isAuthPermissionsOK, namespace, requiredPermissions } from './k8s'
 
 async function run(): Promise<void> {
-  const input = await getInputFromStdin()
-
-  const args = input['args']
-  const command = input['command']
-  const responseFile = input['responseFile']
-  const state = input['state']
-
   let exitCode = 0
   try {
+    const input = await getInputFromStdin()
+
+    const args = input['args']
+    const command = input['command']
+    const responseFile = input['responseFile']
+    const state = input['state']
     if (!(await isAuthPermissionsOK())) {
       throw new Error(
         `The Service account needs the following permissions ${JSON.stringify(


### PR DESCRIPTION
There might be situation where reading from standard input fails. In that case, we should encapsulate that exception within the try catch block to avoid unhandeled Promise rejection exception and provide more information about the error