### PR TITLE
Remove command for service containers and use service options as args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hooks",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hooks",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -159,14 +159,19 @@ function createPodSpec(
   jobContainer = false
 ): k8s.V1Container {
   if (!container.entryPoint && jobContainer) {
-    container.entryPoint = DEFAULT_CONTAINER_ENTRY_POINT
+    container.entryPoint = [DEFAULT_CONTAINER_ENTRY_POINT]
     container.entryPointArgs = DEFAULT_CONTAINER_ENTRY_POINT_ARGS
+  } else if (!container.entryPoint && !jobContainer) {
+    container.entryPoint = undefined
+    container.entryPointArgs = container.createOptions
+      ? container.createOptions.split(' ')
+      : undefined
   }
 
   const podContainer = {
     name,
     image: container.image,
-    command: [container.entryPoint],
+    command: container.entryPoint,
     args: container.entryPointArgs,
     ports: containerPorts(container)
   } as k8s.V1Container


### PR DESCRIPTION
Hi team,

First of all I'm not developer, I got more infra background, so sorry if it's not perfect as-is.

To continue on #45, I still had my services not start cause of empty command in the k8s container definition.
I then patch the code and deploy it on a test environnement and got it working.

I then give you my proposal of the fix/feature improvement, but I didn't figured out how to implement the test that check everything ok, if need from your point of view.