### PR TITLE
Pass full process env for pull command to support creds helpers

### DIFF
--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -99,7 +99,7 @@ export async function containerPull(
   dockerArgs.push(image)
   for (let i = 0; i < 3; i++) {
     try {
-      await runDockerCommand(dockerArgs, { env: process.env })
+      await runDockerCommand(dockerArgs)
       return
     } catch {
       core.info(`docker pull failed on attempt: ${i + 1}`)

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -99,7 +99,7 @@ export async function containerPull(
   dockerArgs.push(image)
   for (let i = 0; i < 3; i++) {
     try {
-      await runDockerCommand(dockerArgs)
+      await runDockerCommand(dockerArgs, { env: process.env })
       return
     } catch {
       core.info(`docker pull failed on attempt: ${i + 1}`)

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -9,7 +9,7 @@ const exec = require('@actions/exec')
 export interface RunDockerCommandOptions {
   workingDir?: string
   input?: Buffer
-  env?: { [key: string]: string | undefined }
+  env?: { [key: string]: string }
 }
 
 export async function runDockerCommand(
@@ -61,7 +61,9 @@ export function optionsWithDockerEnvs(
     newOptions.env[key] = value as string
   }
 
-  newOptions.env["PATH"] = process.env.PATH
+  if (process.env.PATH) {
+    newOptions.env['PATH'] = process.env.PATH
+  }
 
   return newOptions
 }

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -9,7 +9,7 @@ const exec = require('@actions/exec')
 export interface RunDockerCommandOptions {
   workingDir?: string
   input?: Buffer
-  env?: { [key: string]: string | undefined }
+  env?: { [key: string]: string }
 }
 
 export async function runDockerCommand(
@@ -41,7 +41,8 @@ export function optionsWithDockerEnvs(
     'DOCKER_HOST',
     'DOCKER_STACK_ORCHESTRATOR',
     'DOCKER_TLS_VERIFY',
-    'BUILDKIT_PROGRESS'
+    'BUILDKIT_PROGRESS',
+    'PATH'
   ])
   const dockerEnvs = {}
   for (const key in process.env) {

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -9,7 +9,7 @@ const exec = require('@actions/exec')
 export interface RunDockerCommandOptions {
   workingDir?: string
   input?: Buffer
-  env?: { [key: string]: string }
+  env?: { [key: string]: string | undefined }
 }
 
 export async function runDockerCommand(

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -9,7 +9,7 @@ const exec = require('@actions/exec')
 export interface RunDockerCommandOptions {
   workingDir?: string
   input?: Buffer
-  env?: { [key: string]: string }
+  env?: { [key: string]: string | undefined }
 }
 
 export async function runDockerCommand(
@@ -41,8 +41,7 @@ export function optionsWithDockerEnvs(
     'DOCKER_HOST',
     'DOCKER_STACK_ORCHESTRATOR',
     'DOCKER_TLS_VERIFY',
-    'BUILDKIT_PROGRESS',
-    'PATH'
+    'BUILDKIT_PROGRESS'
   ])
   const dockerEnvs = {}
   for (const key in process.env) {
@@ -61,6 +60,8 @@ export function optionsWithDockerEnvs(
   for (const [key, value] of Object.entries(dockerEnvs)) {
     newOptions.env[key] = value as string
   }
+
+  newOptions.env["PATH"] = process.env.PATH
 
   return newOptions
 }


### PR DESCRIPTION
This change supports using docker credential helpers like https://github.com/awslabs/amazon-ecr-credential-helper.

Such helpers require we pass path as well. Alternatively, we can pass full process.env to this command