### PR TITLE
Ensure response consist no matter having ports or not.

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -125,12 +125,11 @@ function generateResponseFile(
   )
   if (serviceContainers?.length) {
     response.context['services'] = serviceContainers.map(c => {
-      if (!c.ports?.length) {
-        return { image: c.image }
-      }
       const ctxPorts: ContextPorts = {}
-      for (const port of c.ports) {
-        ctxPorts[port.containerPort] = port.hostPort
+      if (c.ports) {
+        for (const port of c.ports) {
+          ctxPorts[port.containerPort] = port.hostPort
+        }
       }
 
       return {


### PR DESCRIPTION
`"container":{"id":null,"network":null,"ports":{}}`
`"services":[{"id":null,"network":null,"ports":null}]`

The service's `ports` is `NULL` instead of `{}` which causes the runner hit null ref exceptions.
We will fix the runner in the next version as well, but in the short term, we will just patch the hock since it's easy/cheap to release.