### PR TITLE
docker: Do not overwrite entrypoint if it has already been set or if it is Service container

### DIFF
--- a/packages/docker/src/hooks/prepare-job.ts
+++ b/packages/docker/src/hooks/prepare-job.ts
@@ -40,7 +40,7 @@ export async function prepareJob(
   if (!container?.image) {
     core.info('No job container provided, skipping')
   } else {
-    setupContainer(container)
+    setupContainer(container, true)
 
     const configLocation = await registryLogin(container.registry)
     try {
@@ -174,9 +174,11 @@ function generateResponseFile(
   writeToResponseFile(responseFile, JSON.stringify(response))
 }
 
-function setupContainer(container): void {
-  container.entryPointArgs = [`-f`, `/dev/null`]
-  container.entryPoint = 'tail'
+function setupContainer(container, jobContainer = false): void {
+  if (!container.entryPoint && jobContainer) {
+    container.entryPointArgs = [`-f`, `/dev/null`]
+    container.entryPoint = 'tail'
+  }
 }
 
 function generateNetworkName(): string {


### PR DESCRIPTION
related: https://github.com/actions/runner-container-hooks/issues/44

When using service container with container hooks for docker, is it possible to stop the overwriting of the entrypoint?

Currently, container hooks for docker does not allow the use of service container for some docker images.
This is because the setupContainer function sets `tail` as entryPoint field in any case.
This behavior prevents, for example, postgres or mysql cannot be started (by overriding their configured entrypoint).

setupContainer function: 
https://github.com/actions/runner-container-hooks/blob/ebbe2bdaffea3efb4f0ac1eaf1b381be53a78bdc/packages/docker/src/hooks/prepare-job.ts#L178-L179

I think this is the same problem as https://github.com/actions/runner-container-hooks/issues/44. So, I tried to write a patch based on https://github.com/actions/runner-container-hooks/pull/45.

I didn't know why the entrypoint was overwritten initially, so if you have a workaround, I would appreciate it if you could let me know.
