### PR TITLE
docker: Consider the string quoted for the argument passed as options in service container

### DIFF
--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -38,7 +38,7 @@ export async function createContainer(
     }
   }
   if (args.createOptions) {
-    dockerArgs.push(...args.createOptions.split(' '))
+    dockerArgs.push(...splitCreateOptions(args.createOptions))
   }
 
   if (args.environmentVariables) {
@@ -308,6 +308,13 @@ export async function registryLogin(registry?: Registry): Promise<string> {
   return configLocation
 }
 
+function splitCreateOptions(createOptions: string): string[] {
+  return Array.from(
+    createOptions.matchAll(/"([^"]+)"|'([^']+)'|(\S+)/g),
+    m => m[1] || m[2] || m[3]
+  )
+}
+
 export async function registryLogout(configLocation: string): Promise<void> {
   if (configLocation) {
     await dockerLogout(configLocation)
@@ -398,7 +405,7 @@ export async function containerRun(
   }
 
   if (args.createOptions) {
-    dockerArgs.push(...args.createOptions.split(' '))
+    dockerArgs.push(...splitCreateOptions(args.createOptions))
   }
   if (args.environmentVariables) {
     for (const [key] of Object.entries(args.environmentVariables)) {


### PR DESCRIPTION
When specifying a string like the following in `options` of the service container, the container fails to start with an "invalid reference format" error. This PR addresses that issue with minimal changes.

```yaml
db:
  image: mysql:8.0
  ports:
    - 3306:3306
  env:
    MYSQL_ALLOW_EMPTY_PASSWORD: 1
  options: >-
    --health-cmd "mysqladmin ping"
    --health-interval 10s
    --health-timeout 5s
    --health-retries 5
```

In the main branch, additional arguments received in `options` are split using split(' '):

- https://github.com/actions/runner-container-hooks/blob/ebbe2bdaffea3efb4f0ac1eaf1b381be53a78bdc/packages/docker/src/dockerCommands/container.ts#L41
- https://github.com/actions/runner-container-hooks/blob/ebbe2bdaffea3efb4f0ac1eaf1b381be53a78bdc/packages/docker/src/dockerCommands/container.ts#L401

In other words, the example above is interpreted as follows (pay attention to the content of the health-cmd argument):

```javascript
['--health-cmd', '"mysqladmin', 'ping"', '--health-interval', '10s', '--health-timeout', '5s', '--health-retries', '5']
```

This splitting method is invalid as arguments passed to the command executed with `@actions/exec`.
Therefore, when executing `docker create` with this `options`, it results in an `invalid reference format` error.

Regarding this issue, I consider it challenging to parse the options correctly while maintaining compatibility. 
Therefore, I have made a change not to split string values that are enclosed in `"` or `'`. 
As a result of this modification, the previous example is interpreted as follows.

```javascript
['--health-cmd', 'mysqladmin ping', '--health-interval', '10s', '--health-timeout', '5s', '--health-retries', '5']
```

With this change, the service container is successfully started.