### PR TITLE
Fix argument order for 'docker pull'

### DIFF
--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -91,11 +91,12 @@ export async function containerPull(
   image: string,
   configLocation: string
 ): Promise<void> {
-  const dockerArgs: string[] = ['pull']
+  const dockerArgs: string[] = []
   if (configLocation) {
     dockerArgs.push('--config')
     dockerArgs.push(configLocation)
   }
+  dockerArgs.push('pull')
   dockerArgs.push(image)
   for (let i = 0; i < 3; i++) {
     try {


### PR DESCRIPTION
The optional --config option must come *before* the pull argument.

```
❯ docker pull --config file debian:latest
unknown flag: --config
See 'docker pull --help'.
❯ docker --config file pull debian:latest
latest: Pulling from library/debian
bba7bb10d5ba: Already exists
Digest: sha256:d568e251e460295a8743e9d5ef7de673c5a8f9027db11f4e666e96fb5bed708e
Status: Downloaded newer image for debian:latest
docker.io/library/debian:latest

❯ docker info
Client: Docker Engine - Community
 Version:    24.0.2
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.10.5
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)                                                                                                                                                         Version:  v2.18.1
    Path:     /usr/libexec/docker/cli-plugins/docker-compose

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 136
 Server Version: 24.0.2
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
 runc version: v1.1.7-0-g860f061
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 5.15.90.1-microsoft-standard-WSL2
 Operating System: Ubuntu 20.04.6 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 8
 Total Memory: 19.41GiB
 Name: LAPTOP-J0S02JV8
 ID: LXUW:G5T7:DOFS:UXGJ:I6JH:4A4X:P6CI:OTGW:4BMH:A4O6:MJTF:GBTU
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```