### PR TITLE
Add option to use the kubernetes scheduler for workflow pods

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -13,7 +13,8 @@ import {
   createPod,
   isPodContainerAlpine,
   prunePods,
-  waitForPodPhases
+  waitForPodPhases,
+  getPrepareJobTimeoutSeconds
 } from '../k8s'
 import {
   containerVolumes,
@@ -91,7 +92,8 @@ export async function prepareJob(
     await waitForPodPhases(
       createdPod.metadata.name,
       new Set([PodPhase.RUNNING]),
-      new Set([PodPhase.PENDING])
+      new Set([PodPhase.PENDING]),
+      getPrepareJobTimeoutSeconds()
     )
   } catch (err) {
     await prunePods()

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -25,6 +25,8 @@ const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
 const k8sBatchV1Api = kc.makeApiClient(k8s.BatchV1Api)
 const k8sAuthorizationV1Api = kc.makeApiClient(k8s.AuthorizationV1Api)
 
+const DEFAULT_WAIT_FOR_POD_TIME_SECONDS = 10 * 60 // 10 min
+
 export const POD_VOLUME_NAME = 'work'
 
 export const requiredPermissions = [
@@ -358,7 +360,7 @@ export async function waitForPodPhases(
   podName: string,
   awaitingPhases: Set<PodPhase>,
   backOffPhases: Set<PodPhase>,
-  maxTimeSeconds = 10 * 60 // 10 min
+  maxTimeSeconds = DEFAULT_WAIT_FOR_POD_TIME_SECONDS
 ): Promise<void> {
   const backOffManager = new BackOffManager(maxTimeSeconds)
   let phase: PodPhase = PodPhase.UNKNOWN
@@ -379,6 +381,22 @@ export async function waitForPodPhases(
   } catch (error) {
     throw new Error(`Pod ${podName} is unhealthy with phase status ${phase}`)
   }
+}
+
+export function getPrepareJobTimeoutSeconds(): number {
+  const envTimeoutSeconds =
+    process.env['ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS']
+
+  if (!envTimeoutSeconds) {
+    return DEFAULT_WAIT_FOR_POD_TIME_SECONDS
+  }
+
+  const timeoutSeconds = parseInt(envTimeoutSeconds, 10)
+  if (!timeoutSeconds) {
+    return DEFAULT_WAIT_FOR_POD_TIME_SECONDS
+  }
+
+  return timeoutSeconds
 }
 
 async function getPodPhase(podName: string): Promise<PodPhase> {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -10,7 +10,12 @@ import {
   getVolumeClaimName,
   RunnerInstanceLabel
 } from '../hooks/constants'
-import { PodPhase, mergePodSpecWithOptions, mergeObjectMeta } from './utils'
+import {
+  PodPhase,
+  mergePodSpecWithOptions,
+  mergeObjectMeta,
+  useKubeScheduler
+} from './utils'
 
 const kc = new k8s.KubeConfig()
 
@@ -86,7 +91,11 @@ export async function createPod(
   appPod.spec = new k8s.V1PodSpec()
   appPod.spec.containers = containers
   appPod.spec.restartPolicy = 'Never'
-  appPod.spec.nodeName = await getCurrentNodeName()
+
+  if (!useKubeScheduler()) {
+    appPod.spec.nodeName = await getCurrentNodeName()
+  }
+
   const claimName = getVolumeClaimName()
   appPod.spec.volumes = [
     {
@@ -142,7 +151,10 @@ export async function createJob(
   job.spec.template.metadata.annotations = {}
   job.spec.template.spec.containers = [container]
   job.spec.template.spec.restartPolicy = 'Never'
-  job.spec.template.spec.nodeName = await getCurrentNodeName()
+
+  if (!useKubeScheduler()) {
+    job.spec.template.spec.nodeName = await getCurrentNodeName()
+  }
 
   const claimName = getVolumeClaimName()
   job.spec.template.spec.volumes = [

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -392,7 +392,10 @@ export function getPrepareJobTimeoutSeconds(): number {
   }
 
   const timeoutSeconds = parseInt(envTimeoutSeconds, 10)
-  if (!timeoutSeconds) {
+  if (!timeoutSeconds || timeoutSeconds <= 0) {
+    core.warning(
+      `Prepare job timeout is invalid ("${timeoutSeconds}"): use an int > 0`
+    )
     return DEFAULT_WAIT_FOR_POD_TIME_SECONDS
   }
 

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -6,6 +6,7 @@ import { Mount } from 'hooklib'
 import * as path from 'path'
 import { v1 as uuidv4 } from 'uuid'
 import { POD_VOLUME_NAME } from './index'
+import { JOB_CONTAINER_EXTENSION_NAME } from '../hooks/constants'
 
 export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
 export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
@@ -178,7 +179,9 @@ export function mergeContainerWithOptions(
 ): void {
   for (const [key, value] of Object.entries(from)) {
     if (key === 'name') {
-      core.warning("Skipping name override: name can't be overwritten")
+      if (value !== base.name && value !== JOB_CONTAINER_EXTENSION_NAME) {
+        core.warning("Skipping name override: name can't be overwritten")
+      }
       continue
     } else if (key === 'image') {
       core.warning("Skipping image override: image can't be overwritten")

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
 export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
 
 export const ENV_HOOK_TEMPLATE_PATH = 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE'
+export const ENV_USE_KUBE_SCHEDULER = 'ACTIONS_RUNNER_USE_KUBE_SCHEDULER'
 
 export function containerVolumes(
   userMountVolumes: Mount[] = [],
@@ -255,6 +256,10 @@ export function readExtensionFromFile(): k8s.V1PodTemplateSpec | undefined {
     throw new Error(`Failed to parse ${filePath}`)
   }
   return doc as k8s.V1PodTemplateSpec
+}
+
+export function useKubeScheduler(): boolean {
+  return process.env[ENV_USE_KUBE_SCHEDULER] === 'true'
 }
 
 export enum PodPhase {

--- a/packages/k8s/tests/prepare-job-test.ts
+++ b/packages/k8s/tests/prepare-job-test.ts
@@ -5,6 +5,7 @@ import { createContainerSpec, prepareJob } from '../src/hooks/prepare-job'
 import { TestHelper } from './test-setup'
 import {
   ENV_HOOK_TEMPLATE_PATH,
+  ENV_USE_KUBE_SCHEDULER,
   generateContainerName,
   readExtensionFromFile
 } from '../src/k8s/utils'
@@ -128,6 +129,17 @@ describe('Prepare job', () => {
     expect(got.spec?.containers[2].image).toBe('ubuntu:latest')
     expect(got.spec?.containers[2].command).toEqual(['sh'])
     expect(got.spec?.containers[2].args).toEqual(['-c', 'sleep 60'])
+  })
+
+  it('should not throw exception using kube scheduler', async () => {
+    // only for rwx volumes or single node cluster
+    process.env[ENV_USE_KUBE_SCHEDULER] = 'true'
+
+    await expect(
+      prepareJob(prepareJobData.args, prepareJobOutputFilePath)
+    ).resolves.not.toThrow()
+
+    delete process.env[ENV_USE_KUBE_SCHEDULER]
   })
 
   test.each([undefined, null, []])(

--- a/packages/k8s/tests/prepare-job-test.ts
+++ b/packages/k8s/tests/prepare-job-test.ts
@@ -132,7 +132,7 @@ describe('Prepare job', () => {
   })
 
   it('should not throw exception using kube scheduler', async () => {
-    // only for rwx volumes or single node cluster
+    // only for ReadWriteMany volumes or single node cluster
     process.env[ENV_USE_KUBE_SCHEDULER] = 'true'
 
     await expect(


### PR DESCRIPTION
As described in https://github.com/actions/runner-container-hooks/issues/112 workflow pods aren't going via the kubernetes scheduler, resulting in failed "initialize containers" steps if the already selected node is out of resources. With the following changes I was able to get this working.

This PR adds two new environment variables: `ACTIONS_RUNNER_USE_KUBE_SCHEDULER` and `ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS`.

When set to `true`, the former skips setting the node name and let's the kubernetes scheduler handle the workflow pod. This would only work on a single node cluster (important for the newly added test) or when `ReadWriteMany` volumes are used.

The latter can be used to increase the timeout to for example 6 hours from the default 10 minutes. This will be necessary for scenarios where the cluster runs out of resources and we want to handle this more gracefully. When using the kubernetes scheduler the pod will remain pending until resources are available somewhere in the cluster.

Also a quick fix was added to skip the name override warning which is always there when using the pod template.