### PR TITLE
Docker and K8s: Fix shell arguments when split by the runner

### DIFF
--- a/packages/docker/package-lock.json
+++ b/packages/docker/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.1.1",
         "hooklib": "file:../hooklib",
+        "shlex": "^2.1.2",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -4629,6 +4630,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8929,6 +8935,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -13,6 +13,7 @@
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
     "hooklib": "file:../hooklib",
+    "shlex": "^2.1.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -444,7 +444,7 @@ export async function isContainerAlpine(containerId: string): Promise<boolean> {
     containerId,
     'sh',
     '-c',
-    "[ $(cat /etc/*release* | grep -i -e '^ID=*alpine*' -c) != 0 ] || exit 1"
+    `'[ $(cat /etc/*release* | grep -i -e "^ID=*alpine*" -c) != 0 ] || exit 1'`
   ]
   try {
     await runDockerCommand(dockerArgs)

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -5,6 +5,7 @@ import * as core from '@actions/core'
 import { env } from 'process'
 // Import this way otherwise typescript has errors
 const exec = require('@actions/exec')
+const shlex = require('shlex')
 
 export interface RunDockerCommandOptions {
   workingDir?: string
@@ -17,6 +18,7 @@ export async function runDockerCommand(
   options?: RunDockerCommandOptions
 ): Promise<string> {
   options = optionsWithDockerEnvs(options)
+  args = fixArgs(args)
   const pipes = await exec.getExecOutput('docker', args, options)
   if (pipes.exitCode !== 0) {
     core.error(`Docker failed with exit code ${pipes.exitCode}`)
@@ -82,6 +84,10 @@ export function sanitize(val: string): string {
     }
   }
   return newNameBuilder.join('')
+}
+
+export function fixArgs(args: string[]): string[] {
+  return shlex.split(args.join(' '))
 }
 
 export function checkEnvironment(): void {

--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -14,7 +14,8 @@
         "@actions/io": "^1.1.2",
         "@kubernetes/client-node": "^0.18.1",
         "hooklib": "file:../hooklib",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "shlex": "^2.1.2"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -4163,6 +4164,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8116,6 +8122,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -18,7 +18,8 @@
     "@actions/io": "^1.1.2",
     "@kubernetes/client-node": "^0.18.1",
     "hooklib": "file:../hooklib",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "shlex": "^2.1.2"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -23,7 +23,8 @@ import {
   generateContainerName,
   mergeContainerWithOptions,
   readExtensionFromFile,
-  PodPhase
+  PodPhase,
+  fixArgs
 } from '../k8s/utils'
 import { JOB_CONTAINER_EXTENSION_NAME, JOB_CONTAINER_NAME } from './constants'
 
@@ -206,7 +207,7 @@ export function createContainerSpec(
   }
 
   if (container.entryPointArgs?.length > 0) {
-    podContainer.args = container.entryPointArgs
+    podContainer.args = fixArgs(container.entryPointArgs)
   }
 
   podContainer.env = []

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -14,7 +14,8 @@ import {
   containerVolumes,
   PodPhase,
   mergeContainerWithOptions,
-  readExtensionFromFile
+  readExtensionFromFile,
+  fixArgs
 } from '../k8s/utils'
 import { JOB_CONTAINER_EXTENSION_NAME, JOB_CONTAINER_NAME } from './constants'
 
@@ -89,7 +90,7 @@ function createContainerSpec(
     ? [container.entryPoint]
     : undefined
   podContainer.args = container.entryPointArgs?.length
-    ? container.entryPointArgs
+    ? fixArgs(container.entryPointArgs)
     : undefined
 
   if (secretName) {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -511,7 +511,7 @@ export async function isPodContainerAlpine(
       [
         'sh',
         '-c',
-        "[ $(cat /etc/*release* | grep -i -e '^ID=*alpine*' -c) != 0 ] || exit 1"
+        `'[ $(cat /etc/*release* | grep -i -e "^ID=*alpine*" -c) != 0 ] || exit 1'`
       ],
       podName,
       containerName

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -7,6 +7,7 @@ import * as path from 'path'
 import { v1 as uuidv4 } from 'uuid'
 import { POD_VOLUME_NAME } from './index'
 import { JOB_CONTAINER_EXTENSION_NAME } from '../hooks/constants'
+import * as shlex from 'shlex'
 
 export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
 export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
@@ -281,4 +282,8 @@ function mergeLists<T>(base?: T[], from?: T[]): T[] {
   }
   b.push(...from)
   return b
+}
+
+export function fixArgs(args: string[]): string[] {
+  return shlex.split(args.join(' '))
 }

--- a/packages/k8s/tests/run-container-step-test.ts
+++ b/packages/k8s/tests/run-container-step-test.ts
@@ -72,7 +72,7 @@ describe('Run container step', () => {
     runContainerStepData.args.entryPoint = 'bash'
     runContainerStepData.args.entryPointArgs = [
       '-c',
-      'if [[ -z $NODE_ENV ]]; then exit 1; fi'
+      "'if [[ -z $NODE_ENV ]]; then exit 1; fi'"
     ]
     await expect(
       runContainerStep(runContainerStepData.args)


### PR DESCRIPTION
When runner passes arguments to the hook, there may be situations where quoted strings are interpreted as separate arguments.

This PR addresses the issue and fixes the arguments based on `shlex` expansion

Fixes the [issue in this discussion](https://github.com/orgs/community/discussions/70488) 