### PR TITLE
Fix for broken Kubernetes mode

### DIFF
--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -89,7 +89,7 @@ function createContainerSpec(
     ? [container.entryPoint]
     : undefined
   podContainer.args = container.entryPointArgs?.length
-    ? container.entryPointArgs.map(arg => arg.replace(/^"(.*)"$/, '$1'))
+    ? container.entryPointArgs.map(arg => arg.replace(/^"/, '').replace(/"$/, ''))
     : undefined
 
   if (secretName) {

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -89,7 +89,7 @@ function createContainerSpec(
     ? [container.entryPoint]
     : undefined
   podContainer.args = container.entryPointArgs?.length
-    ? container.entryPointArgs
+    ? container.entryPointArgs.map(arg => arg.replace(/^"(.*)"$/, '$1'))
     : undefined
 
   if (secretName) {


### PR DESCRIPTION
# Issue
Within the current implementation of `hooks 0.4.0` in combination with `ARC 0.6.1` running in `mode=kubernetes` and the lastest `runner 2.311.0` on an Enterprise instance, the handover of `args` towards the k8s job container is buggy. The `args` will be forwarded to the `job pod` in a escaped way, which will be disrespected by some tools like `mkdocs`:

```
Usage: mkdocs [OPTIONS] COMMAND [ARGS]...

  MkDocs - Project documentation with Markdown.

Options:
  -V, --version  Show the version and exit.
  -q, --quiet    Silence warnings
  -v, --verbose  Enable verbose output
  -h, --help     Show this message and exit.

Commands:
  build      Build the MkDocs documentation
  gh-deploy  Deploy your documentation to GitHub Pages
  new        Create a new MkDocs project
  serve      Run the builtin development server
```

This fix will remove the leading and ending quotes from the `args` before handing over to the k8s pod creation.


# Example 1

The `args` as an array with all parameters as a space separated string

### action.yml
```yaml
name: Build MKDocs

runs:
  using: docker
  image: docker://squidfunk/mkdocs-material:latest
  entrypoint: mkdocs
  args:
  - build --verbose --strict
```

### Runner to Hooks
```json
["\"build","--verbose","--strict\""]
```

### Pod config without fix
```yaml
  containers:
  - image: squidfunk/mkdocs-material:latest
    command:
    - mkdocs
  - args:
    - '"build'
    - --verbose
    - --string"
```

### Pod config with fix
```yaml
spec:
  containers:
  - image: squidfunk/mkdocs-material:latest
    command:
    - mkdocs
    args:
    - build
    - --verbose
    - --strict
```

# Example 2

The `args` as an array with each parameter as a separate string

### action.yml
```yaml
name: Build MKDocs

runs:
  using: docker
  image: docker://squidfunk/mkdocs-material:latest
  entrypoint: mkdocs
  args:
  - build
  - --verbose
  - --strict
```

### Runner to Hooks
```json
["\"build\"","\"--verbose\"","\"--strict\""]
```

### Pod config without fix
```yaml
  containers:
  - image: squidfunk/mkdocs-material:latest
    command:
    - mkdocs
  - args:
    - '"build"'
    - '"--verbose"'
    - '"--strict"'
```

### Pod config with fix
```yaml
spec:
  containers:
  - image: squidfunk/mkdocs-material:latest
    command:
    - mkdocs
    args:
    - build
    - --verbose
    - --strict
```