### PR TITLE
feat: Expose Docker MTU on Network Creation

### DIFF
--- a/packages/docker/src/dockerCommands/network.ts
+++ b/packages/docker/src/dockerCommands/network.ts
@@ -6,6 +6,12 @@ export async function networkCreate(networkName): Promise<void> {
   dockerArgs.push('--label')
   dockerArgs.push(getRunnerLabel())
   dockerArgs.push(networkName)
+
+  if (process.env.DOCKER_MTU) {
+    dockerArgs.push('--opt')
+    dockerArgs.push(`com.docker.network.driver.mtu=${process.env.DOCKER_MTU}`)
+  }
+
   await runDockerCommand(dockerArgs)
 }
 


### PR DESCRIPTION
Add conditional logic for including `DOCKER_MTU` environment variable in `dockerArgs` in `network.ts` file

Please inform me if we need to modify this to work with hooks more generically.