### PR TITLE
Mount /github/workflow to docker action pods

### DIFF
--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -41,6 +41,11 @@ export function containerVolumes(
         name: POD_VOLUME_NAME,
         mountPath: '/github/file_commands',
         subPath: '_temp/_runner_file_commands'
+      },
+      {
+        name: POD_VOLUME_NAME,
+        mountPath: '/github/workflow',
+        subPath: '_temp/_github_workflow'
       }
     )
     return mounts

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -185,6 +185,20 @@ describe('k8s utils', () => {
       expect(volumes.find(e => e.mountPath === '/__w')).toBeTruthy()
     })
 
+    it('should always have /github/workflow mount if working on container job or container action', () => {
+      let volumes = containerVolumes([], true, true)
+      expect(volumes.find(e => e.mountPath === '/github/workflow')).toBeTruthy()
+      volumes = containerVolumes([], true, false)
+      expect(volumes.find(e => e.mountPath === '/github/workflow')).toBeTruthy()
+      volumes = containerVolumes([], false, true)
+      expect(volumes.find(e => e.mountPath === '/github/workflow')).toBeTruthy()
+
+      volumes = containerVolumes([], false, false)
+      expect(
+        volumes.find(e => e.mountPath === '/github/workflow')
+      ).toBeUndefined()
+    })
+
     it('should have container action volumes', () => {
       let volumes = containerVolumes([], true, true)
       let workspace = volumes.find(e => e.mountPath === '/github/workspace')
@@ -205,11 +219,10 @@ describe('k8s utils', () => {
       expect(fileCommands?.subPath).toBe('_temp/_runner_file_commands')
     })
 
-    it('should have externals, github home and github workflow mounts if job container', () => {
+    it('should have externals, github home mounts if job container', () => {
       const volumes = containerVolumes()
       expect(volumes.find(e => e.mountPath === '/__e')).toBeTruthy()
       expect(volumes.find(e => e.mountPath === '/github/home')).toBeTruthy()
-      expect(volumes.find(e => e.mountPath === '/github/workflow')).toBeTruthy()
     })
 
     it('should throw if user volume source volume path is not in workspace', () => {


### PR DESCRIPTION
`/github/workflow` is set via env GITHUB_EVENT_PATH also in docker actions.
Such path is mount in container jobs pods, and should be(?) mount in similar fashion in other child pods (in this case docker action pods), especially that some docker actions from marketplace, use this path.

Having it inconsistent for container job pod and for docker action pod, makes it impossible to use with ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE and mount via extension, which is shared for both - it will work for docker action pods, but will fail for container job pod (duplicate mount point).

Adding it as default mount seems the only option to be able to properly utilize this ENV (and events in general).