### PR TITLE
Add debug trace for errors

### DIFF
--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -44,8 +44,9 @@ async function run(): Promise<void> {
   } catch (error) {
     core.error(error as Error)
 
-    if (core.isDebug())
+    if (core.isDebug()) {
       console.trace(error)
+    }
 
     process.exit(1)
   }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -44,7 +44,7 @@ async function run(): Promise<void> {
   } catch (error) {
     core.error(error as Error)
 
-    if (core.isDebug() && error instanceof Error && error.stack)
+    if (core.isDebug())
       console.trace(error)
 
     process.exit(1)

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -43,6 +43,10 @@ async function run(): Promise<void> {
     }
   } catch (error) {
     core.error(error as Error)
+
+    if (core.isDebug() && error instanceof Error && error.stack)
+      console.trace(error)
+
     process.exit(1)
   }
 }


### PR DESCRIPTION
This change will increase the debugging capability of the `runner-container-hooks` if something is buggy within the Kubernetes configuration (permission issues, policy configurations, node configurations, ...)

The usual error sadly does not tell anything where the error happen but to contact your local Administrator. Also the console log of the runner is quiet silent about the origin of such errors - even with debug enabled.
![gha_error](https://github.com/actions/runner-container-hooks/assets/508684/f63e9aa3-4c15-44f7-bf6b-04a12be3a175)

This change will simply dump the trace log into the console whenever there is a error happening within the k8s hooks that will point the user towards the direction where to have a look.
![gha_trace](https://github.com/actions/runner-container-hooks/assets/508684/2065914b-8714-419f-a398-677ecefc9c2b)

There would be an alternative implementation by forwarding the log via `core.debug(error.stack)`. This looks better from the console integration. Sadly it does only contain the hints into the minified code - and by this it's hard to track down the root cause of the error.
![gha_debug](https://github.com/actions/runner-container-hooks/assets/508684/4c267851-f021-4b4f-b0a1-a4ecfd826de5)