### PR TITLE
Add debug trace for library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 dist/
 **/tests/_temp/**
 packages/k8s/tests/test-kind.yaml
+*.tsbuildinfo

--- a/packages/docker/package-lock.json
+++ b/packages/docker/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.1.1",
-        "hooklib": "file:../hooklib",
         "shlex": "^2.1.2",
         "uuid": "^8.3.2"
       },
@@ -19,16 +18,17 @@
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.23",
         "@typescript-eslint/parser": "^5.18.0",
-        "@vercel/ncc": "^0.33.4",
+        "@vercel/ncc": "^0.38.1",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.7.0",
         "tsconfig-paths": "^3.14.1",
-        "typescript": "^4.6.3"
+        "typescript": "^4.7.2"
       }
     },
     "../hooklib": {
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1"
@@ -40,7 +40,7 @@
         "eslint": "^8.12.0",
         "eslint-plugin-github": "^4.3.6",
         "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
+        "typescript": "^4.7.2"
       }
     },
     "node_modules/@actions/core": {
@@ -1510,9 +1510,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -2851,10 +2851,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hooklib": {
-      "resolved": "../hooklib",
-      "link": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -5113,9 +5109,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6564,9 +6560,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true
     },
     "abab": {
@@ -7579,19 +7575,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "hooklib": {
-      "version": "file:../hooklib",
-      "requires": {
-        "@actions/core": "^1.9.1",
-        "@types/node": "^17.0.23",
-        "@typescript-eslint/parser": "^5.18.0",
-        "@zeit/ncc": "^0.22.3",
-        "eslint": "^8.12.0",
-        "eslint-plugin-github": "^4.3.6",
-        "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
-      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -9280,9 +9263,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -2,17 +2,16 @@
   "name": "dockerhooks",
   "version": "0.1.0",
   "description": "",
-  "main": "lib/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest --runInBand",
-    "build": "npx tsc && npx ncc build"
+    "build": "npx ncc build --source-map"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
-    "hooklib": "file:../hooklib",
     "shlex": "^2.1.2",
     "uuid": "^8.3.2"
   },
@@ -20,11 +19,11 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
     "@typescript-eslint/parser": "^5.18.0",
-    "@vercel/ncc": "^0.33.4",
+    "@vercel/ncc": "^0.38.1",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.14.1",
-    "typescript": "^4.6.3"
+    "typescript": "^4.7.2"
   }
 }

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -5,7 +5,7 @@ import {
   Registry,
   RunContainerStepArgs,
   ServiceContainerInfo
-} from 'hooklib/lib'
+} from 'hooklib'
 import * as path from 'path'
 import { env } from 'process'
 import { v4 as uuidv4 } from 'uuid'

--- a/packages/docker/src/hooks/prepare-job.ts
+++ b/packages/docker/src/hooks/prepare-job.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import { ContextPorts, PrepareJobArgs, writeToResponseFile } from 'hooklib/lib'
+import { ContextPorts, PrepareJobArgs, writeToResponseFile } from 'hooklib'
 import { exit } from 'process'
 import { v4 as uuidv4 } from 'uuid'
 import {

--- a/packages/docker/src/hooks/run-container-step.ts
+++ b/packages/docker/src/hooks/run-container-step.ts
@@ -1,4 +1,4 @@
-import { RunContainerStepArgs } from 'hooklib/lib'
+import { RunContainerStepArgs } from 'hooklib'
 import { v4 as uuidv4 } from 'uuid'
 import {
   containerBuild,

--- a/packages/docker/src/hooks/run-script-step.ts
+++ b/packages/docker/src/hooks/run-script-step.ts
@@ -1,4 +1,4 @@
-import { RunScriptStepArgs } from 'hooklib/lib'
+import { RunScriptStepArgs } from 'hooklib'
 import { containerExecStep } from '../dockerCommands'
 
 export async function runScriptStep(

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -5,7 +5,7 @@ import {
   PrepareJobArgs,
   RunContainerStepArgs,
   RunScriptStepArgs
-} from 'hooklib/lib'
+} from 'hooklib'
 import { exit } from 'process'
 import {
   cleanupJob,

--- a/packages/docker/tsconfig.json
+++ b/packages/docker/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "outDir": "./lib",
+      "rootDir": "..",
+      "outDir": "./lib"
     },
     "include": [
       "./src"

--- a/packages/docker/tsconfig.json
+++ b/packages/docker/tsconfig.json
@@ -1,11 +1,12 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "baseUrl": "./",
       "outDir": "./lib",
-      "rootDir": "./src"
     },
     "include": [
       "./src"
+    ],
+    "references": [
+      { "path": "../hooklib" }
     ]
   }

--- a/packages/hooklib/package-lock.json
+++ b/packages/hooklib/package-lock.json
@@ -18,7 +18,7 @@
         "eslint": "^8.12.0",
         "eslint-plugin-github": "^4.3.6",
         "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
+        "typescript": "^4.7.2"
       }
     },
     "node_modules/@actions/core": {
@@ -2450,9 +2450,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4284,9 +4284,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/packages/hooklib/package.json
+++ b/packages/hooklib/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "tsc --build",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts"

--- a/packages/hooklib/package.json
+++ b/packages/hooklib/package.json
@@ -20,7 +20,7 @@
     "eslint": "^8.12.0",
     "eslint-plugin-github": "^4.3.6",
     "prettier": "^2.6.2",
-    "typescript": "^4.6.3"
+    "typescript": "^4.7.2"
   },
   "dependencies": {
     "@actions/core": "^1.9.1"

--- a/packages/hooklib/package.json
+++ b/packages/hooklib/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc --build",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc --build",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts"

--- a/packages/hooklib/src/interfaces.ts
+++ b/packages/hooklib/src/interfaces.ts
@@ -88,5 +88,5 @@ export interface ContainerContext {
 }
 
 export interface ContextPorts {
-  [source: string]: string // source -> target
+  [source: number]: number // source -> target
 }

--- a/packages/hooklib/tsconfig.json
+++ b/packages/hooklib/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "rootDir": "./src",
       "outDir": "./lib",
       "composite": true
     },

--- a/packages/hooklib/tsconfig.json
+++ b/packages/hooklib/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "baseUrl": "./",
+      "rootDir": "./src",
       "outDir": "./lib",
-      "rootDir": "./src"
+      "composite": true
     },
     "include": [
       "./src"

--- a/packages/hooklib/tsconfig.json
+++ b/packages/hooklib/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
+      "rootDir": "..",
       "outDir": "./lib",
+      "declaration": true,
+      "declarationMap": true,
       "composite": true
     },
     "include": [

--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -13,7 +13,6 @@
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2",
         "@kubernetes/client-node": "^0.18.1",
-        "hooklib": "file:../hooklib",
         "js-yaml": "^4.1.0",
         "shlex": "^2.1.2"
       },
@@ -28,6 +27,7 @@
     },
     "../hooklib": {
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1"
@@ -2365,10 +2365,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hooklib": {
-      "resolved": "../hooklib",
-      "link": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -6732,19 +6728,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "hooklib": {
-      "version": "file:../hooklib",
-      "requires": {
-        "@actions/core": "^1.9.1",
-        "@types/node": "^17.0.23",
-        "@typescript-eslint/parser": "^5.18.0",
-        "@zeit/ncc": "^0.22.3",
-        "eslint": "^8.12.0",
-        "eslint-plugin-github": "^4.3.6",
-        "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
-      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",

--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -19,10 +19,10 @@
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.23",
-        "@vercel/ncc": "^0.33.4",
+        "@vercel/ncc": "^0.38.1",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.4",
-        "typescript": "^4.6.3"
+        "typescript": "^4.7.2"
       }
     },
     "../hooklib": {
@@ -1279,9 +1279,9 @@
       "dev": true
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -5915,9 +5915,9 @@
       "dev": true
     },
     "@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true
     },
     "abab": {

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -2,10 +2,10 @@
   "name": "kubehooks",
   "version": "0.1.0",
   "description": "",
-  "main": "lib/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest --runInBand",
-    "build": "tsc && npx ncc build --source-map",
+    "build": "npx ncc build --source-map",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts"
@@ -23,9 +23,9 @@
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
-    "@vercel/ncc": "^0.33.4",
+    "@vercel/ncc": "^0.38.1",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typescript": "^4.6.3"
+    "typescript": "^4.7.2"
   }
 }

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest --runInBand",
-    "build": "tsc && npx ncc build",
+    "build": "tsc && npx ncc build --source-map",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts"

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -17,7 +17,6 @@
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2",
     "@kubernetes/client-node": "^0.18.1",
-    "hooklib": "file:../hooklib",
     "js-yaml": "^4.1.0",
     "shlex": "^2.1.2"
   },

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -165,8 +165,7 @@ function generateResponseFile(
       const ctxPorts: ContextPorts = {}
       if (c.ports?.length) {
         for (const port of c.ports) {
-          if (port.hostPort)
-            ctxPorts[port.containerPort] = port.hostPort
+          if (port.hostPort) ctxPorts[port.containerPort] = port.hostPort
         }
       }
 
@@ -191,7 +190,7 @@ async function copyExternalsToRoot(): Promise<void> {
 }
 
 export function createContainerSpec(
-  container: JobContainerInfo|ServiceContainerInfo,
+  container: JobContainerInfo | ServiceContainerInfo,
   name: string,
   jobContainer = false,
   extension?: k8s.V1PodTemplateSpec
@@ -206,7 +205,7 @@ export function createContainerSpec(
     image: container.image,
     ports: containerPorts(container)
   } as k8s.V1Container
-  if ("workingDirectory" in container) {
+  if ('workingDirectory' in container) {
     podContainer.workingDir = container.workingDirectory
   }
 
@@ -219,10 +218,8 @@ export function createContainerSpec(
   }
 
   podContainer.env = []
-  if(container.environmentVariables) {
-    for (const [key, value] of Object.entries(
-      container.environmentVariables
-    )) {
+  if (container.environmentVariables) {
+    for (const [key, value] of Object.entries(container.environmentVariables)) {
       if (value && key !== 'HOME') {
         podContainer.env.push({ name: key, value: value as string })
       }

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -3,6 +3,7 @@ import * as io from '@actions/io'
 import * as k8s from '@kubernetes/client-node'
 import {
   JobContainerInfo,
+  ServiceContainerInfo,
   ContextPorts,
   PrepareJobArgs,
   writeToResponseFile
@@ -145,8 +146,8 @@ function generateResponseFile(
     const mainContainerContextPorts: ContextPorts = {}
     if (mainContainer?.ports) {
       for (const port of mainContainer.ports) {
-        mainContainerContextPorts[port.containerPort] =
-          mainContainerContextPorts.hostPort
+        if (port.hostPort)
+          mainContainerContextPorts[port.containerPort] = port.hostPort
       }
     }
 
@@ -164,7 +165,8 @@ function generateResponseFile(
       const ctxPorts: ContextPorts = {}
       if (c.ports?.length) {
         for (const port of c.ports) {
-          ctxPorts[port.containerPort] = port.hostPort
+          if (port.hostPort)
+            ctxPorts[port.containerPort] = port.hostPort
         }
       }
 
@@ -189,7 +191,7 @@ async function copyExternalsToRoot(): Promise<void> {
 }
 
 export function createContainerSpec(
-  container: JobContainerInfo,
+  container: JobContainerInfo|ServiceContainerInfo,
   name: string,
   jobContainer = false,
   extension?: k8s.V1PodTemplateSpec
@@ -204,7 +206,7 @@ export function createContainerSpec(
     image: container.image,
     ports: containerPorts(container)
   } as k8s.V1Container
-  if (container.workingDirectory) {
+  if ("workingDirectory" in container) {
     podContainer.workingDir = container.workingDirectory
   }
 
@@ -212,16 +214,18 @@ export function createContainerSpec(
     podContainer.command = [container.entryPoint]
   }
 
-  if (container.entryPointArgs?.length > 0) {
+  if (container.entryPointArgs && container.entryPointArgs.length > 0) {
     podContainer.args = fixArgs(container.entryPointArgs)
   }
 
   podContainer.env = []
-  for (const [key, value] of Object.entries(
-    container['environmentVariables']
-  )) {
-    if (value && key !== 'HOME') {
-      podContainer.env.push({ name: key, value: value as string })
+  if(container.environmentVariables) {
+    for (const [key, value] of Object.entries(
+      container.environmentVariables
+    )) {
+      if (value && key !== 'HOME') {
+        podContainer.env.push({ name: key, value: value as string })
+      }
     }
   }
 

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -44,8 +44,9 @@ async function run(): Promise<void> {
   } catch (error) {
     core.error(error as Error)
 
-    if (core.isDebug())
+    if (core.isDebug()) {
       console.trace(error)
+    }
 
     process.exit(1)
   }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -44,7 +44,7 @@ async function run(): Promise<void> {
   } catch (error) {
     core.error(error as Error)
 
-    if (core.isDebug() && error instanceof Error && error.stack)
+    if (core.isDebug())
       console.trace(error)
 
     process.exit(1)

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -1,5 +1,11 @@
 import * as core from '@actions/core'
-import { Command, getInputFromStdin, prepareJobArgs } from 'hooklib'
+import {
+  Command,
+  getInputFromStdin,
+  PrepareJobArgs,
+  RunScriptStepArgs,
+  RunContainerStepArgs
+} from 'hooklib'
 import {
   cleanupJob,
   prepareJob,
@@ -27,16 +33,16 @@ async function run(): Promise<void> {
     let exitCode = 0
     switch (command) {
       case Command.PrepareJob:
-        await prepareJob(args as prepareJobArgs, responseFile)
+        await prepareJob(args as PrepareJobArgs, responseFile)
         return process.exit(0)
       case Command.CleanupJob:
         await cleanupJob()
         return process.exit(0)
       case Command.RunScriptStep:
-        await runScriptStep(args, state, null)
+        await runScriptStep(args as RunScriptStepArgs, state, null)
         return process.exit(0)
       case Command.RunContainerStep:
-        exitCode = await runContainerStep(args)
+        exitCode = await runContainerStep(args as RunContainerStepArgs)
         return process.exit(exitCode)
       default:
         throw new Error(`Command not recognized: ${command}`)

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -43,6 +43,10 @@ async function run(): Promise<void> {
     }
   } catch (error) {
     core.error(error as Error)
+
+    if (core.isDebug() && error instanceof Error && error.stack)
+      console.trace(error)
+
     process.exit(1)
   }
 }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -43,11 +43,9 @@ async function run(): Promise<void> {
     }
   } catch (error) {
     core.error(error as Error)
-
-    if (core.isDebug()) {
-      console.trace(error)
+    if (error instanceof Error && error.stack) {
+      core.debug(error?.stack?.split('\n').slice(1).join('\n'))
     }
-
     process.exit(1)
   }
 }

--- a/packages/k8s/src/index.ts
+++ b/packages/k8s/src/index.ts
@@ -44,7 +44,7 @@ async function run(): Promise<void> {
   } catch (error) {
     core.error(error as Error)
     if (error instanceof Error && error.stack) {
-      core.debug(error?.stack?.split('\n').slice(1).join('\n'))
+      core.debug(error.stack)
     }
     process.exit(1)
   }

--- a/packages/k8s/tsconfig.json
+++ b/packages/k8s/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "outDir": "./lib",
-      "rootDir": "./src"
+      "outDir": "./lib"
     },
     "include": [
       "./src"

--- a/packages/k8s/tsconfig.json
+++ b/packages/k8s/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-      "baseUrl": "./",
       "outDir": "./lib",
       "rootDir": "./src"
     },
     "include": [
       "./src"
+    ],
+    "references": [
+      { "path": "../hooklib" }
     ]
   }

--- a/packages/k8s/tsconfig.json
+++ b/packages/k8s/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
+      "rootDir": "..",
       "outDir": "./lib"
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    // "outDir": "./lib",
-    // "rootDir": "./packages",
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
@@ -11,8 +9,8 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
@@ -67,7 +65,9 @@
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
     "paths": {
-      "hooklib": ["hooklib/src"]
+      "hooklib":     ["hooklib/src"],
+      "kubehooks":   ["k8s/src"],
+      "dockerhooks": ["docker/src"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    "outDir": "./lib",
-    "rootDir": "./packages",
+    // "outDir": "./lib",
+    // "rootDir": "./packages",
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
@@ -12,8 +12,8 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
@@ -43,7 +43,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "./packages",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
@@ -65,6 +65,9 @@
 
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "paths": {
+      "hooklib": ["hooklib/src"]
+    }
   }
 }


### PR DESCRIPTION
As a __self hosted runner administrator__ i want so know why my runners are crashing. If this is related to k8s, a stack trace often does help to pin down the origin of the issue.

Therefore, this change does improve the debug capability of the k8s hook implementation by providing a stack trace via the debug output if an exception happend.

## Before the change
![before](https://github.com/actions/runner-container-hooks/assets/508684/d33ffd57-c330-465a-ad3c-f0e678e394e2)

## After the change
![after](https://github.com/actions/runner-container-hooks/assets/508684/5a6f2bb6-61d8-4175-9ec2-2354ea527c7b)

## Change summary
The primary change is to enable a correct `sourceMap` output for the code, so the stack trace will show up the `.ts` origin with the correct line number of the trace and not some location within the minified / baked `index.js`.

* The linkage between the `packages/hooklib` and the `packages/k8s` and `packages/docker` was changed from a JS based include into a TypeScript composite build. To make this happen, the `baseUrl` & `rootUrl` required adaptation.
* The build by using a combination of `tsc` followed by `ncc` was replaced with a direct call of `ncc` due to otherwise the line number reference got lost.
* There where some type inconsistencies that pop up within the `k8s/package.json` that appear now due to the linkage is happening now on a typed based linkage. I guess there was also a bug within the `mainContainerContextPorts[port.containerPort]` assignment.
* `ncc` and `typescript` library update was required due to the used version caused a bug.