### PR TITLE
Add support for custom `DOCKER_HOST` mount

### DIFF
--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -53,9 +53,15 @@ export async function createContainer(
     ...(args.systemMountVolumes || [])
   ]
   for (const mountVolume of mountVolumes) {
-    dockerArgs.push(
-      `-v=${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}`
-    )
+    if (mountVolume.sourceVolumePath === '/var/run/docker.sock') {
+      dockerArgs.push(
+        `-v=${env.DOCKER_HOST || mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}`
+      )
+    } else {
+      dockerArgs.push(
+        `-v=${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}`
+      )
+    }
   }
   if (args.entryPoint) {
     dockerArgs.push(`--entrypoint`)
@@ -413,12 +419,19 @@ export async function containerRun(
     ...(args.systemMountVolumes || [])
   ]
   for (const mountVolume of mountVolumes) {
-    dockerArgs.push(`-v`)
-    dockerArgs.push(
-      `${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}${
-        mountVolume.readOnly ? ':ro' : ''
-      }`
-    )
+    if (mountVolume.sourceVolumePath === '/var/run/docker.sock') {
+      dockerArgs.push(
+        `-v=${env.DOCKER_HOST || mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}${
+          mountVolume.readOnly ? ':ro' : ''
+        }`
+      )
+    } else {
+      dockerArgs.push(
+        `-v=${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}${
+          mountVolume.readOnly ? ':ro' : ''
+        }`
+      )
+    }
   }
 
   if (args['entryPoint']) {

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -54,7 +54,11 @@ export async function createContainer(
   ]
   for (const mountVolume of mountVolumes) {
     let sourceVolumePath = mountVolume.sourceVolumePath
-    if (sourceVolumePath === '/var/run/docker.sock' && env.DOCKER_HOST) {
+    if (
+      sourceVolumePath === '/var/run/docker.sock' &&
+      env.DOCKER_HOST &&
+      env.DOCKER_HOST.startsWith('unix://')
+    ) {
       sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
     dockerArgs.push(
@@ -420,7 +424,11 @@ export async function containerRun(
   ]
   for (const mountVolume of mountVolumes) {
     let sourceVolumePath = mountVolume.sourceVolumePath
-    if (sourceVolumePath === '/var/run/docker.sock' && env.DOCKER_HOST) {
+    if (
+      sourceVolumePath === '/var/run/docker.sock' &&
+      env.DOCKER_HOST &&
+      env.DOCKER_HOST.startsWith('unix://')
+    ) {
       sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
     dockerArgs.push(

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -61,11 +61,7 @@ export async function createContainer(
     ) {
       sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
-    dockerArgs.push(
-      `-v=${sourceVolumePath}:${mountVolume.targetVolumePath}${
-        mountVolume.readOnly ? ':ro' : ''
-      }`
-    )
+    dockerArgs.push(`-v=${sourceVolumePath}:${mountVolume.targetVolumePath}`)
   }
   if (args.entryPoint) {
     dockerArgs.push(`--entrypoint`)
@@ -431,8 +427,9 @@ export async function containerRun(
     ) {
       sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
+    dockerArgs.push(`-v`)
     dockerArgs.push(
-      `-v=${sourceVolumePath}:${mountVolume.targetVolumePath}${
+      `${sourceVolumePath}:${mountVolume.targetVolumePath}${
         mountVolume.readOnly ? ':ro' : ''
       }`
     )

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -53,15 +53,15 @@ export async function createContainer(
     ...(args.systemMountVolumes || [])
   ]
   for (const mountVolume of mountVolumes) {
-    if (mountVolume.sourceVolumePath === '/var/run/docker.sock') {
-      dockerArgs.push(
-        `-v=${env.DOCKER_HOST || mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}`
-      )
-    } else {
-      dockerArgs.push(
-        `-v=${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}`
-      )
+    let sourceVolumePath = mountVolume.sourceVolumePath
+    if (sourceVolumePath === '/var/run/docker.sock' && env.DOCKER_HOST) {
+      sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
+    dockerArgs.push(
+      `-v=${sourceVolumePath}:${mountVolume.targetVolumePath}${
+        mountVolume.readOnly ? ':ro' : ''
+      }`
+    )
   }
   if (args.entryPoint) {
     dockerArgs.push(`--entrypoint`)
@@ -419,19 +419,15 @@ export async function containerRun(
     ...(args.systemMountVolumes || [])
   ]
   for (const mountVolume of mountVolumes) {
-    if (mountVolume.sourceVolumePath === '/var/run/docker.sock') {
-      dockerArgs.push(
-        `-v=${env.DOCKER_HOST || mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}${
-          mountVolume.readOnly ? ':ro' : ''
-        }`
-      )
-    } else {
-      dockerArgs.push(
-        `-v=${mountVolume.sourceVolumePath}:${mountVolume.targetVolumePath}${
-          mountVolume.readOnly ? ':ro' : ''
-        }`
-      )
+    let sourceVolumePath = mountVolume.sourceVolumePath
+    if (sourceVolumePath === '/var/run/docker.sock' && env.DOCKER_HOST) {
+      sourceVolumePath = env.DOCKER_HOST.replace('unix://', '')
     }
+    dockerArgs.push(
+      `-v=${sourceVolumePath}:${mountVolume.targetVolumePath}${
+        mountVolume.readOnly ? ':ro' : ''
+      }`
+    )
   }
 
   if (args['entryPoint']) {


### PR DESCRIPTION
This PR adds support for customizing the docker socket mount used in GHA containers. 

This will be specially useful for rootless docker setups where the socket will be in a custom location depending on the user.

If this is seen as a breaking change perhaps a different environment variable could be used (other than DOCKER_HOST) or a env toggle to enable the new behavior