### PR TITLE
k8s: start logging from the beginning

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -452,7 +452,6 @@ export async function getPodLogs(
 
   const r = await log.log(namespace(), podName, containerName, logStream, {
     follow: true,
-    tailLines: 50,
     pretty: false,
     timestamps: false
   })


### PR DESCRIPTION
I noticed that for jobs that quickly generate a lot of logs (like super-linter) the first lines of the log are missing. However sometimes in there are the information you need to debug a problem further.

Luckily this problem is easily fixed by removing the `tailLines: 50`.