### PR TITLE
Added ACTIONS_RUNNER_INJECT_RUNNER_SERVICE_ACCOUNT environment variable

### DIFF
--- a/packages/k8s/src/hooks/constants.ts
+++ b/packages/k8s/src/hooks/constants.ts
@@ -39,6 +39,10 @@ export function getSecretName(): string {
   )}-secret-${uuidv4().substring(0, STEP_POD_NAME_SUFFIX_LENGTH)}`
 }
 
+export function shouldInjectRunnerServiceAccount(): boolean {
+  return process.env.ACTIONS_RUNNER_INJECT_RUNNER_SERVICE_ACCOUNT === 'true'
+}
+
 export const MAX_POD_NAME_LENGTH = 63
 export const STEP_POD_NAME_SUFFIX_LENGTH = 8
 export const CONTAINER_EXTENSION_PREFIX = '$'


### PR DESCRIPTION
Hi team! :)

As mentioned [here](https://github.com/actions/actions-runner-controller/issues/3745), we in eDo hit the same behavior of @Hchanni.

Analysing the problem, we found out that when a runner starts a `-workflow` pod with hooks, it doesn't automatically propagate its service account.

In our case with Workload Identities, this is needed, and even if we can workaround the problem creating a ConfigMap and placing in the runner container as a file to make an override (using `ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE`), this is still a feature that could be helpful for lot of people.

This won't be the default behavior because I understand it's a breaking change, but I added a new environment variable `ACTIONS_RUNNER_INJECT_RUNNER_SERVICE_ACCOUNT` to allow the automatic "parent injection"