### PR TITLE
Remove `@actions/runner-akvelon` from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @actions/actions-launch @actions/runner-akvelon
+* @actions/actions-launch


### PR DESCRIPTION
`@actions/runner-akvelon` is not currently being used.