### PR TITLE
Update to the latest available actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sed -i "s|{{PATHTOREPO}}|$(pwd)|" packages/k8s/tests/test-kind.yaml
         name: Setup kind cluster yaml config
       - uses: helm/kind-action@v1.2.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,17 +5,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm install
         name: Install dependencies
       - run: npm run bootstrap
         name: Bootstrap the packages
       - run: npm run build-all
         name: Build packages
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: releaseVersion
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const hookVersion = require('./package.json').version
@@ -36,9 +35,8 @@ jobs:
           echo "k8s-sha=$sha_k8s" >> $GITHUB_OUTPUT
       - name: replace SHA
         id: releaseNotes
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             var releaseNotes = fs.readFileSync('${{ github.workspace }}/releaseNotes.md', 'utf8').replace(/<HOOK_VERSION>/g, '${{ steps.releaseVersion.outputs.version }}')


### PR DESCRIPTION
A lot of these workflows are using deprecated actions with old Node versions.

As a follow-up, we should set up Dependabot to automate this.


`.github/workflows/release.yaml` also needs to be re-written to avoid usage of `actions/create-release` and `actions/upload-release-asset` which are archived.