### PR TITLE
feat(k8s): add /github/home to containerAction mounts and surface createSecretForEnvs errors #181

### DIFF
--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -28,7 +28,13 @@ export async function runContainerStep(
 
   let secretName: string | undefined = undefined
   if (stepContainer.environmentVariables) {
-    secretName = await createSecretForEnvs(stepContainer.environmentVariables)
+    try {
+      secretName = await createSecretForEnvs(stepContainer.environmentVariables)
+    } catch (err) {
+      core.debug(`createSecretForEnvs failed: ${JSON.stringify(err)}`)
+      const message = (err as any)?.response?.body?.message || err
+      throw new Error(`failed to create script environment: ${message}`)
+    }
   }
 
   const extension = readExtensionFromFile()

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -44,6 +44,11 @@ export function containerVolumes(
       },
       {
         name: POD_VOLUME_NAME,
+        mountPath: '/github/home',
+        subPath: '_temp/_github_home'
+      },
+      {
+        name: POD_VOLUME_NAME,
         mountPath: '/github/workflow',
         subPath: '_temp/_github_workflow'
       }


### PR DESCRIPTION
Hi maintainers, this PR is meant to accomplish two things:

1. Make the `/github/home` directory available from container actions, which is a path frequently relied on by actions creating files in a user's home (`$HOME/.netrc` for instance)
2. Surface error messages when the container hooks fail to create their required Kubernetes secret for storing environment variables.

I ran into both issues during a k8s runner deployment and a similar concern was raised in #181. I'd prefer not to maintain my internal for and custom runner image just for this additional mount if I don't have to

Thanks for the consideration!