### PR TITLE
support --name create option

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -58,7 +58,7 @@ export async function prepareJob(
       core.debug(`Adding service '${service.image}' to pod definition`)
       return createContainerSpec(
         service,
-        generateContainerName(service.image),
+        generateContainerName(service),
         false,
         extension
       )
@@ -159,7 +159,7 @@ function generateResponseFile(
 
   if (args.services?.length) {
     const serviceContainerNames =
-      args.services?.map(s => generateContainerName(s.image)) || []
+      args.services?.map(s => generateContainerName(s)) || []
 
     response.context['services'] = appPod?.spec?.containers
       ?.filter(c => serviceContainerNames.includes(c.name))


### PR DESCRIPTION
Currently,  in a k8s-based runner, one cannot have multiple services using the same image because the image name is used as the container name, which must be unique. This PR proposes to resolve that by adding support for setting an explicit name for the container using a `--name` create option, similarly to the docker-based runner.