### PR TITLE
support alternative network modes

### DIFF
--- a/packages/docker/src/hooks/prepare-job.ts
+++ b/packages/docker/src/hooks/prepare-job.ts
@@ -31,9 +31,13 @@ export async function prepareJob(
     core.info('No containers exist, skipping hook invocation')
     exit(0)
   }
-  const networkName = generateNetworkName()
-  // Create network
-  await networkCreate(networkName)
+
+  let networkName = process.env.ACTIONS_RUNNER_NETWORK_DRIVER
+  if (!networkName) {
+    networkName = generateNetworkName()
+    // Create network
+    await networkCreate(networkName)
+  }
 
   // Create Job Container
   let containerMetadata: ContainerMetadata | undefined = undefined


### PR DESCRIPTION
Currently, the docker-based runner creates a custom bridge network per container job. With this PR, you can configure your runner to skip creation of the bridge network and use the network mode specified in a new env var `ACTIONS_RUNNER_NETWORK_DRIVER`. The onus is on the runner administrator to understand the impact and implications of their choice. This change has been tested successfully with the `host` network option.