### PR TITLE
Make script executor store the script command and execute it 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hooks",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hooks",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -1,10 +1,24 @@
-<!-- ## Features -->
+## Features
 
-<!-- ## Bugs -->
+- k8s: Use pod affinity when KubeScheduler is enabled [#212]
+- docker: support alternative network modes [#209]
+
+## Bugs
+
+- Expose CI=true and GITHUB_ACTIONS env variables [#215]
+- k8s: add /github/home to containerAction mounts and surface createSecretForEnvs errors [#198]
+- k8s: start logging from the beginning [#184]
 
 ## Misc
 
-- Bump `@kubernetes/client-node` from 0.18.1 to 0.22.0 in /packages/k8s [#182]
+- Bump node in tests to node 22 since node14 is quite old [#216]
+- Bump jsonpath-plus from 10.1.0 to 10.3.0 in /packages/k8s [#213]
+- Bump braces from 3.0.2 to 3.0.3 in /packages/hooklib [#194]
+- Bump cross-spawn from 7.0.3 to 7.0.6 in /packages/k8s [#196]
+- Bump ws from 7.5.8 to 7.5.10 in /packages/k8s [#192]
+- Remove dependency on deprecated release actions [#193]
+- Update to the latest available actions [#191]
+
 
 ## SHA-256 Checksums
 


### PR DESCRIPTION
Currently we are just running `sh -e ${bash script location}` in the script executor. This change will writes the script command to a temporary file location on the server and execute that instead. This will remove the need to share a mounted volume between the runner node and the workload node or having to copy over the bash file with the script content.