### PR TITLE
Separate CI docker and k8s tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Check linter
         run: |
           npm run lint
-          git diff --exit-code
+          git diff --exit-code -- . ':!packages/k8s/tests/test-kind.yaml'
 
   docker-tests:
     name: Docker Hook Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,45 @@ on:
     paths-ignore:
     - '**.md'
   workflow_dispatch:
+
 jobs:
-  build:
+  format-and-lint:
+    name: Format & Lint Checks
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+        name: Install dependencies
+      - run: npm run bootstrap
+        name: Bootstrap the packages
+      - run: npm run build-all
+        name: Build packages
+      - run: npm run format-check
+        name: Check formatting
+      - name: Check linter
+        run: |
+          npm run lint
+          git diff --exit-code
+
+  docker-tests:
+    name: Docker Hook Tests
+    runs-on: ubuntu-latest
+    needs: format-and-lint
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+        name: Install dependencies
+      - run: npm run bootstrap
+        name: Bootstrap the packages
+      - run: npm run build-all
+        name: Build packages
+      - name: Run Docker tests
+        run: npm run test --prefix packages/docker
+
+  k8s-tests:
+    name: Kubernetes Hook Tests
+    runs-on: ubuntu-latest
+    needs: format-and-lint
     steps:
       - uses: actions/checkout@v4
       - run: sed -i "s|{{PATHTOREPO}}|$(pwd)|" packages/k8s/tests/test-kind.yaml
@@ -22,10 +58,5 @@ jobs:
         name: Bootstrap the packages
       - run: npm run build-all
         name: Build packages
-      - run: npm run format-check
-      - name: Check linter
-        run: |
-          npm run lint
-          git diff --exit-code -- ':!packages/k8s/tests/test-kind.yaml'
-      - name: Run tests
-        run: npm run test
+      - name: Run Kubernetes tests
+        run: npm run test --prefix packages/k8s


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflow for CI to improve clarity and enforce code quality checks before running tests. The main change is splitting the previous single `build` job into multiple, more focused jobs for formatting, linting, and testing Docker and Kubernetes hooks.

**Workflow Restructuring and Quality Checks:**

* Split the previous `build` job into three separate jobs: `format-and-lint`, `docker-tests`, and `k8s-tests`, to better organize the workflow and enforce sequential checks.
* Added a dedicated `format-and-lint` job that installs dependencies, bootstraps packages, builds all packages, checks code formatting, and runs the linter, ensuring no code is formatted or linted incorrectly before proceeding.
* Updated the Docker and Kubernetes test jobs (`docker-tests` and `k8s-tests`) to depend on the successful completion of `format-and-lint`, enforcing code quality before running tests.
* Modified the Kubernetes tests step to run only the Kubernetes tests with `npm run test --prefix packages/k8s`, instead of running all tests.
* Ensured that Docker tests are run in a separate job with `npm run test --prefix packages/docker`, improving test isolation and clarity.