### PR TITLE
Sort 'find' output before hashing for consistency

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -428,11 +428,11 @@ export async function execCpToPod(
   const delay = 1000
   for (let i = 0; i < attempts; i++) {
     try {
-      const got = await execCalculateOutputHashSorted(podName, JOB_CONTAINER_NAME, [
-        'sh',
-        '-c',
-        listDirAllCommand(containerPath)
-      ])
+      const got = await execCalculateOutputHashSorted(
+        podName,
+        JOB_CONTAINER_NAME,
+        ['sh', '-c', listDirAllCommand(containerPath)]
+      )
 
       if (got !== want) {
         core.debug(
@@ -459,11 +459,11 @@ export async function execCpFromPod(
   core.debug(
     `Copying from pod ${podName} ${containerPath} to ${targetRunnerPath}`
   )
-  const want = await execCalculateOutputHashSorted(podName, JOB_CONTAINER_NAME, [
-    'sh',
-    '-c',
-    listDirAllCommand(containerPath)
-  ])
+  const want = await execCalculateOutputHashSorted(
+    podName,
+    JOB_CONTAINER_NAME,
+    ['sh', '-c', listDirAllCommand(containerPath)]
+  )
 
   let attempt = 0
   while (true) {


### PR DESCRIPTION
This PR fixes the issue reported in [265](https://github.com/actions/runner-container-hooks/issues/265). 

As described in that issue output of `find` wasn't consistent when running with various container images which was causing `The hash of the directory does not match the expected value` to be emitted until the maximum of [15](https://github.com/actions/runner-container-hooks/blob/main/packages/k8s/src/k8s/index.ts#L409) was reached and then it workflow steps would continue.

Emitting of that message happened twice for each step in the workflow which caused delays of about 30s [for each step], making it more than just a nuisance.
 
PR introduces sorting of the `find` output before hash is computed and compared. Making resulting hash consistent which fixes the comparison. After the fix, runner doesn't emit any unexpected hash values messages.

Initially I tested with just piping the output to Linux's `sort` command - that worked, but it's hard to predict if sorting would be consistent across different versions and platforms. Sorting in TS seems most reliable since runner uses the same Node binary between runner and workflow (at least I assume as much). 

I tested in our environment by running a custom image with these changes. Seems to work fine.
Screenshots of before and after below.
