### PR TITLE
fix: calculate hash again after failure

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -427,16 +427,16 @@ export async function execCpToPod(
     }
   }
 
-  const want = await localCalculateOutputHashSorted([
-    'sh',
-    '-c',
-    listDirAllCommand(runnerPath)
-  ])
-
   let attempts = 15
   const delay = 1000
   for (let i = 0; i < attempts; i++) {
     try {
+      const want = await localCalculateOutputHashSorted([
+        'sh',
+        '-c',
+        listDirAllCommand(runnerPath)
+      ])
+
       const got = await execCalculateOutputHashSorted(
         podName,
         JOB_CONTAINER_NAME,
@@ -467,11 +467,6 @@ export async function execCpFromPod(
   const targetRunnerPath = `${parentRunnerPath}/${path.basename(containerPath)}`
   core.debug(
     `Copying from pod ${podName} ${containerPath} to ${targetRunnerPath}`
-  )
-  const want = await execCalculateOutputHashSorted(
-    podName,
-    JOB_CONTAINER_NAME,
-    ['sh', '-c', listDirAllCommand(containerPath)]
   )
 
   let attempt = 0
@@ -533,6 +528,12 @@ export async function execCpFromPod(
   const delay = 1000
   for (let i = 0; i < attempts; i++) {
     try {
+      const want = await execCalculateOutputHashSorted(
+        podName,
+        JOB_CONTAINER_NAME,
+        ['sh', '-c', listDirAllCommand(containerPath)]
+      )
+
       const got = await localCalculateOutputHashSorted([
         'sh',
         '-c',


### PR DESCRIPTION
The hash from the source is calculated only once. The source hash is checked with the destination hash, but if the destination hash does not match, the destination match is calculated again.

The problem is that if the source hash is incorrect, the check will keep failing because the source hash is never re-calculated.

Now, in the event that the hashes do not match, the hash of the source and the destination are calculated again.