### PR TITLE
Overwrite runnner file commands

### DIFF
--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -48,6 +48,7 @@ export async function runScriptStep(
     'SRC=/__w/_temp_pre',
     'DST=/__w/_temp',
     // Overwrite _runner_file_commands
+    'cp -a "$SRC/_runner_file_commands/." "$DST/_runner_file_commands"',
     `find "$SRC" -type f ! -path "*/_runner_file_commands/*" -exec sh -c '
     rel="\${1#$2/}"
     target="$3/$rel"


### PR DESCRIPTION
After https://github.com/actions/runner-container-hooks/commit/f8e1cae6774204ca736aecd6bfb1ea16d941d275 the file commands were not being copied to the _temp directory correctly.