### PR TITLE
fix: use `contextName` to generate container name

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -62,7 +62,7 @@ export async function prepareJob(
     services = args.services.map(service => {
       return createContainerSpec(
         service,
-        generateContainerName(service.image),
+        generateContainerName(service),
         false,
         extension
       )
@@ -193,7 +193,7 @@ function generateResponseFile(
 
   if (args.services?.length) {
     const serviceContainerNames =
-      args.services?.map(s => generateContainerName(s.image)) || []
+      args.services?.map(s => generateContainerName(s)) || []
 
     response.context['services'] = appPod?.spec?.containers
       ?.filter(c => serviceContainerNames.includes(c.name))

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -157,14 +157,14 @@ function scriptEnv(envs?: { [key: string]: string }): string {
 }
 
 export function generateContainerName(service: ServiceContainerInfo): string {
-  const nameWithTag = service.image.split('/').pop()
-  const name = nameWithTag?.split(':')[0]
+  const imageNameWithTag = service.image.split('/').pop()
+  const imageName = imageNameWithTag?.split(':')[0]
 
-  if (!name) {
+  if (!imageName) {
     throw new Error(`Image definition '${service.image}' is invalid`)
   }
 
-  return `${service.contextName}_${name}`
+  return `${service.contextName}_${imageName}`
 }
 
 // Overwrite or append based on container options

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -164,7 +164,7 @@ export function generateContainerName(service: ServiceContainerInfo): string {
     throw new Error(`Image definition '${service.image}' is invalid`)
   }
 
-  return `${service.contextName}_${imageName}`
+  return `${service.contextName}-${imageName}`
 }
 
 // Overwrite or append based on container options

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -5,7 +5,7 @@ import * as core from '@actions/core'
 import { v1 as uuidv4 } from 'uuid'
 import { CONTAINER_EXTENSION_PREFIX } from '../hooks/constants'
 import * as shlex from 'shlex'
-import { Mount } from 'hooklib'
+import { Mount, ServiceContainerInfo } from 'hooklib'
 
 export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
 export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
@@ -156,15 +156,15 @@ function scriptEnv(envs?: { [key: string]: string }): string {
   return `env ${envBuffer.join(' ')} `
 }
 
-export function generateContainerName(image: string): string {
-  const nameWithTag = image.split('/').pop()
+export function generateContainerName(service: ServiceContainerInfo): string {
+  const nameWithTag = service.image.split('/').pop()
   const name = nameWithTag?.split(':')[0]
 
   if (!name) {
-    throw new Error(`Image definition '${image}' is invalid`)
+    throw new Error(`Image definition '${service.image}' is invalid`)
   }
 
-  return name
+  return `${service.contextName}_${name}`
 }
 
 // Overwrite or append based on container options

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -201,30 +201,52 @@ describe('k8s utils', () => {
   })
 
   describe('generate container name', () => {
-    it('should return the container name from image string', () => {
+    it('should return the container name from "contextName" and "image" strings combined', () => {
       expect(
-        generateContainerName('public.ecr.aws/localstack/localstack')
-      ).toEqual('localstack')
+        generateContainerName({
+          contextName: 'localstack',
+          image: 'public.ecr.aws/localstack/localstack'
+        })
+      ).toEqual('localstack_localstack')
       expect(
-        generateContainerName(
-          'public.ecr.aws/url/with/multiple/slashes/postgres:latest'
-        )
-      ).toEqual('postgres')
-      expect(generateContainerName('postgres')).toEqual('postgres')
-      expect(generateContainerName('postgres:latest')).toEqual('postgres')
-      expect(generateContainerName('localstack/localstack')).toEqual(
-        'localstack'
-      )
-      expect(generateContainerName('localstack/localstack:latest')).toEqual(
-        'localstack'
-      )
+        generateContainerName({
+          contextName: 'postgres',
+          image: 'public.ecr.aws/url/with/multiple/slashes/postgres:latest'
+        })
+      ).toEqual('postgres_postgres')
+      expect(
+        generateContainerName({ contextName: 'postgres1', image: 'postgres' })
+      ).toEqual('postgres1_postgres')
+      expect(
+        generateContainerName({
+          contextName: 'postgres',
+          image: 'postgres:latest'
+        })
+      ).toEqual('postgres_postgres')
+      expect(
+        generateContainerName({
+          contextName: 'localstack1',
+          image: 'localstack/localstack'
+        })
+      ).toEqual('localstack1_localstack')
+      expect(
+        generateContainerName({
+          contextName: 'localstack2',
+          image: 'localstack/localstack:latest'
+        })
+      ).toEqual('localstack2_localstack')
     })
 
     it('should throw on invalid image string', () => {
       expect(() =>
-        generateContainerName('localstack/localstack/:latest')
+        generateContainerName({
+          contextName: 'invalid',
+          image: 'localstack/localstack/:latest'
+        })
       ).toThrow()
-      expect(() => generateContainerName(':latest')).toThrow()
+      expect(() =>
+        generateContainerName({ contextName: 'invalid', image: ':latest' })
+      ).toThrow()
     })
   })
 

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -207,34 +207,34 @@ describe('k8s utils', () => {
           contextName: 'localstack',
           image: 'public.ecr.aws/localstack/localstack'
         })
-      ).toEqual('localstack_localstack')
+      ).toEqual('localstack-localstack')
       expect(
         generateContainerName({
           contextName: 'postgres',
           image: 'public.ecr.aws/url/with/multiple/slashes/postgres:latest'
         })
-      ).toEqual('postgres_postgres')
+      ).toEqual('postgres-postgres')
       expect(
         generateContainerName({ contextName: 'postgres1', image: 'postgres' })
-      ).toEqual('postgres1_postgres')
+      ).toEqual('postgres1-postgres')
       expect(
         generateContainerName({
           contextName: 'postgres',
           image: 'postgres:latest'
         })
-      ).toEqual('postgres_postgres')
+      ).toEqual('postgres-postgres')
       expect(
         generateContainerName({
           contextName: 'localstack1',
           image: 'localstack/localstack'
         })
-      ).toEqual('localstack1_localstack')
+      ).toEqual('localstack1-localstack')
       expect(
         generateContainerName({
           contextName: 'localstack2',
           image: 'localstack/localstack:latest'
         })
-      ).toEqual('localstack2_localstack')
+      ).toEqual('localstack2-localstack')
     })
 
     it('should throw on invalid image string', () => {

--- a/packages/k8s/tests/prepare-job-test.ts
+++ b/packages/k8s/tests/prepare-job-test.ts
@@ -128,7 +128,7 @@ describe('Prepare job', () => {
 
   it('should not set command + args for service container if not passed in args', async () => {
     const services = prepareJobData.args.services.map(service => {
-      return createContainerSpec(service, generateContainerName(service.image))
+      return createContainerSpec(service, generateContainerName(service))
     }) as [V1Container]
 
     expect(services[0].command).toBe(undefined)


### PR DESCRIPTION
This PR fixes an issue caused by generating the container name using only the image name. Instead, we now include the contextName as well. This is useful when creating multiple containers from the same image, for example a Redis cluster with several shards.