### PR TITLE
fix: Solving the 30-second delay in step

### DIFF
--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -301,5 +301,5 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 export function listDirAllCommand(dir: string): string {
-  return `cd ${shlex.quote(dir)} && find . -not -path '*/_runner_hook_responses*' -exec stat -c '%s %n' {} \\;`
+  return `cd ${shlex.quote(dir)} && find . -type f -not -path '*/_runner_hook_responses*' -exec stat -c '%s %n' {} \\;`
 }


### PR DESCRIPTION
Current situation: Each step synchronizes data between the runner and workflow, but the system uses file and folder hashes to determine if data synchronization is complete.

Problem: Each step currently takes an extra 30 seconds.

Root Cause: The current hash calculation rule is to calculate the hash based on the size of the folder and file. However, folders are calculated differently on different systems or in different environments, even if the files are the same.

Solution: Only verify file consistency.