### PR TITLE
Show container pull errors in the github output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 dist/
 **/tests/_temp/**
 packages/k8s/tests/test-kind.yaml
+.idea

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -673,6 +673,34 @@ export async function pruneSecrets(): Promise<void> {
   )
 }
 
+const UNRECOVERABLE_WAITING_REASONS = new Set([
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'InvalidImageName',
+  'CreateContainerConfigError',
+  'CreateContainerError'
+])
+
+function getContainerErrors(
+  pod: k8s.V1Pod
+): string[] {
+  const errors: string[] = []
+  const allStatuses = [
+    ...(pod.status?.initContainerStatuses ?? []),
+    ...(pod.status?.containerStatuses ?? [])
+  ]
+  for (const cs of allStatuses) {
+    const waiting = cs.state?.waiting
+    if (waiting?.reason && UNRECOVERABLE_WAITING_REASONS.has(waiting.reason)) {
+      const detail = waiting.message
+        ? `${waiting.reason}: ${waiting.message}`
+        : waiting.reason
+      errors.push(`container "${cs.name}": ${detail}`)
+    }
+  }
+  return errors
+}
+
 export async function waitForPodPhases(
   podName: string,
   awaitingPhases: Set<PodPhase>,
@@ -683,7 +711,8 @@ export async function waitForPodPhases(
   let phase: PodPhase = PodPhase.UNKNOWN
   try {
     while (true) {
-      phase = await getPodPhase(podName)
+      const pod = await readPod(podName)
+      phase = parsePodPhase(pod)
       if (awaitingPhases.has(phase)) {
         return
       }
@@ -693,6 +722,14 @@ export async function waitForPodPhases(
           `Pod ${podName} is unhealthy with phase status ${phase}`
         )
       }
+
+      const containerErrors = getContainerErrors(pod)
+      if (containerErrors.length > 0) {
+        throw new Error(
+          `Pod ${podName} has unrecoverable container errors: ${containerErrors.join('; ')}`
+        )
+      }
+
       await backOffManager.backOff()
     }
   } catch (error) {
@@ -721,23 +758,26 @@ export function getPrepareJobTimeoutSeconds(): number {
   return timeoutSeconds
 }
 
-async function getPodPhase(name: string): Promise<PodPhase> {
-  const podPhaseLookup = new Set<string>([
-    PodPhase.PENDING,
-    PodPhase.RUNNING,
-    PodPhase.SUCCEEDED,
-    PodPhase.FAILED,
-    PodPhase.UNKNOWN
-  ])
-  const pod = await k8sApi.readNamespacedPod({
+async function readPod(name: string): Promise<k8s.V1Pod> {
+  return k8sApi.readNamespacedPod({
     name,
     namespace: namespace()
   })
+}
 
+const podPhaseLookup = new Set<string>([
+  PodPhase.PENDING,
+  PodPhase.RUNNING,
+  PodPhase.SUCCEEDED,
+  PodPhase.FAILED,
+  PodPhase.UNKNOWN
+])
+
+function parsePodPhase(pod: k8s.V1Pod): PodPhase {
   if (!pod.status?.phase || !podPhaseLookup.has(pod.status.phase)) {
     return PodPhase.UNKNOWN
   }
-  return pod.status?.phase as PodPhase
+  return pod.status.phase as PodPhase
 }
 
 async function isJobSucceeded(name: string): Promise<boolean> {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -681,9 +681,7 @@ const UNRECOVERABLE_WAITING_REASONS = new Set([
   'CreateContainerError'
 ])
 
-function getContainerErrors(
-  pod: k8s.V1Pod
-): string[] {
+function getContainerErrors(pod: k8s.V1Pod): string[] {
   const errors: string[] = []
   const allStatuses = [
     ...(pod.status?.initContainerStatuses ?? []),
@@ -692,10 +690,7 @@ function getContainerErrors(
   for (const cs of allStatuses) {
     const waiting = cs.state?.waiting
     if (waiting?.reason && UNRECOVERABLE_WAITING_REASONS.has(waiting.reason)) {
-      const detail = waiting.message
-        ? `${waiting.reason}: ${waiting.message}`
-        : waiting.reason
-      errors.push(`container "${cs.name}": ${detail}`)
+      errors.push(`container "${cs.name}": ${waiting.reason}`)
     }
   }
   return errors

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -690,7 +690,7 @@ function getContainerErrors(pod: k8s.V1Pod): string[] {
   for (const cs of allStatuses) {
     const waiting = cs.state?.waiting
     if (waiting?.reason && UNRECOVERABLE_WAITING_REASONS.has(waiting.reason)) {
-      errors.push(`container "${cs.name}": ${waiting.reason}`)
+      errors.push(`container "${cs.name}": ${waiting.reason}${waiting.message ? ` - ${waiting.message}` : ''}`)
     }
   }
   return errors

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -728,8 +728,9 @@ export async function waitForPodPhases(
       await backOffManager.backOff()
     }
   } catch (error) {
+    const additionalPodErrors = error instanceof Error ? error.message : JSON.stringify(error)
     throw new Error(
-      `Pod ${podName} is unhealthy with phase status ${phase}: ${JSON.stringify(error)}`
+      `Pod ${podName} is unhealthy with phase status ${phase}: ${additionalPodErrors}`
     )
   }
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -778,7 +778,9 @@ function getContainerErrors(pod: k8s.V1Pod): string[] {
   for (const cs of allStatuses) {
     const waiting = cs.state?.waiting
     if (waiting?.reason && UNRECOVERABLE_WAITING_REASONS.has(waiting.reason)) {
-      errors.push(`container "${cs.name}": ${waiting.reason}${waiting.message ? ` - ${waiting.message}` : ''}`)
+      errors.push(
+        `container "${cs.name}": ${waiting.reason}${waiting.message ? ` - ${waiting.message}` : ''}`
+      )
     }
   }
   return errors


### PR DESCRIPTION
When a workflow attempts to use an image that does not exist or that the workflow does not have access to it prints out a generic error "Executing the custom container implementation failed. Please contact your self hosted runner administrator." This error is not descriptive enough for users without additional logs from the runners. 

This PR updates the error messages in these cases. If the container failed due to a container error it outputs the error.