### PR TITLE
Fix error serialization in 4 catch blocks where `JSON.stringify(error)` produces `"{}"`

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -430,7 +430,7 @@ export async function execCpToPod(
       attempt++
       if (attempt >= 30) {
         throw new Error(
-          `cpToPod failed after ${attempt} attempts: ${JSON.stringify(error)}`
+          `cpToPod failed after ${attempt} attempts: ${error instanceof Error ? error.message : String(error)}`
         )
       }
       await sleep(1000)
@@ -527,7 +527,7 @@ export async function execCpFromPod(
       attempt++
       if (attempt >= 30) {
         throw new Error(
-          `execCpFromPod failed after ${attempt} attempts: ${JSON.stringify(error)}`
+          `execCpFromPod failed after ${attempt} attempts: ${error instanceof Error ? error.message : String(error)}`
         )
       }
       await sleep(1000)
@@ -574,7 +574,7 @@ export async function waitForJobToComplete(jobName: string): Promise<void> {
         return
       }
     } catch (error) {
-      throw new Error(`job ${jobName} has failed: ${JSON.stringify(error)}`)
+      throw new Error(`job ${jobName} has failed: ${error instanceof Error ? error.message : String(error)}`)
     }
     await backOffManager.backOff()
   }
@@ -697,7 +697,7 @@ export async function waitForPodPhases(
     }
   } catch (error) {
     throw new Error(
-      `Pod ${podName} is unhealthy with phase status ${phase}: ${JSON.stringify(error)}`
+      `Pod ${podName} is unhealthy with phase status ${phase}: ${error instanceof Error ? error.message : String(error)}`
     )
   }
 }

--- a/packages/k8s/tests/error-serialization-test.ts
+++ b/packages/k8s/tests/error-serialization-test.ts
@@ -1,0 +1,200 @@
+import { WritableStreamBuffer } from 'stream-buffers'
+
+const mockExec = jest.fn()
+const mockReadNamespacedPod = jest.fn()
+const mockReadNamespacedJob = jest.fn()
+
+jest.mock('@kubernetes/client-node', () => {
+  return {
+    KubeConfig: jest.fn().mockImplementation(() => ({
+      loadFromDefault: jest.fn(),
+      makeApiClient: jest.fn().mockImplementation(ApiClass => {
+        const name = ApiClass?.name || ApiClass?.toString() || ''
+        if (name.includes('Batch')) {
+          return { readNamespacedJob: mockReadNamespacedJob }
+        }
+        if (name.includes('Authorization')) {
+          return { createSelfSubjectAccessReview: jest.fn() }
+        }
+        return { readNamespacedPod: mockReadNamespacedPod }
+      }),
+      getContexts: jest
+        .fn()
+        .mockReturnValue([{ namespace: 'test-namespace' }])
+    })),
+    Exec: jest.fn().mockImplementation(() => ({ exec: mockExec })),
+    CoreV1Api: class CoreV1Api {},
+    BatchV1Api: class BatchV1Api {},
+    AuthorizationV1Api: class AuthorizationV1Api {},
+    Log: jest.fn()
+  }
+})
+
+jest.mock('tar-fs', () => ({
+  default: {
+    pack: jest.fn().mockReturnValue({ pipe: jest.fn() }),
+    extract: jest.fn().mockReturnValue({
+      on: jest.fn(),
+      pipe: jest.fn()
+    })
+  },
+  __esModule: true
+}))
+
+jest.mock('../src/k8s/utils', () => {
+  const actual = jest.requireActual('../src/k8s/utils')
+  return {
+    ...actual,
+    sleep: jest.fn().mockResolvedValue(undefined)
+  }
+})
+
+import {
+  execCpToPod,
+  execCpFromPod,
+  waitForJobToComplete,
+  waitForPodPhases
+} from '../src/k8s'
+import { PodPhase } from '../src/k8s/utils'
+
+describe('error serialization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE'] = 'test-namespace'
+  })
+
+  afterEach(() => {
+    delete process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE']
+  })
+
+  describe('execCpToPod', () => {
+    it('should include Error.message in thrown error after retries', async () => {
+      mockExec.mockRejectedValue(new Error('connection refused'))
+
+      await expect(
+        execCpToPod('test-pod', '/tmp/src', '/workspace')
+      ).rejects.toThrow('cpToPod failed after 30 attempts: connection refused')
+    })
+
+    it('should use String() for non-Error throwables', async () => {
+      mockExec.mockRejectedValue('raw string error')
+
+      await expect(
+        execCpToPod('test-pod', '/tmp/src', '/workspace')
+      ).rejects.toThrow('cpToPod failed after 30 attempts: raw string error')
+    })
+
+    it('should not produce empty braces in error message', async () => {
+      mockExec.mockRejectedValue(new Error('ETIMEOUT'))
+
+      await expect(
+        execCpToPod('test-pod', '/tmp/src', '/workspace')
+      ).rejects.toThrow(
+        expect.not.objectContaining({ message: expect.stringContaining('{}') })
+      )
+    })
+  })
+
+  describe('execCpFromPod', () => {
+    it('should include Error.message in thrown error after retries', async () => {
+      mockExec.mockRejectedValue(new Error('container not found'))
+
+      await expect(
+        execCpFromPod('test-pod', '/workspace/output', '/tmp/dst')
+      ).rejects.toThrow(
+        'execCpFromPod failed after 30 attempts: container not found'
+      )
+    })
+
+    it('should use String() for non-Error throwables', async () => {
+      mockExec.mockRejectedValue(42)
+
+      await expect(
+        execCpFromPod('test-pod', '/workspace/output', '/tmp/dst')
+      ).rejects.toThrow('execCpFromPod failed after 30 attempts: 42')
+    })
+  })
+
+  describe('waitForJobToComplete', () => {
+    it('should include Error.message when job fails', async () => {
+      mockReadNamespacedJob.mockResolvedValue({
+        status: { failed: 1 }
+      })
+
+      await expect(waitForJobToComplete('my-job')).rejects.toThrow(
+        'job my-job has failed: job my-job has failed'
+      )
+    })
+
+    it('should include Error.message when API call throws', async () => {
+      mockReadNamespacedJob.mockRejectedValue(
+        new Error('403 Forbidden')
+      )
+
+      await expect(waitForJobToComplete('my-job')).rejects.toThrow(
+        'job my-job has failed: 403 Forbidden'
+      )
+    })
+
+    it('should use String() for non-Error throwables from API', async () => {
+      mockReadNamespacedJob.mockRejectedValue('unexpected API failure')
+
+      await expect(waitForJobToComplete('my-job')).rejects.toThrow(
+        'job my-job has failed: unexpected API failure'
+      )
+    })
+  })
+
+  describe('waitForPodPhases', () => {
+    it('should include error message when pod enters unhealthy phase', async () => {
+      mockReadNamespacedPod.mockResolvedValue({
+        status: { phase: 'Failed' }
+      })
+
+      await expect(
+        waitForPodPhases(
+          'test-pod',
+          new Set([PodPhase.RUNNING]),
+          new Set([PodPhase.PENDING])
+        )
+      ).rejects.toThrow(
+        /Pod test-pod is unhealthy with phase status Failed/
+      )
+    })
+
+    it('should include Error.message when API call throws', async () => {
+      mockReadNamespacedPod.mockRejectedValue(
+        new Error('network timeout')
+      )
+
+      await expect(
+        waitForPodPhases(
+          'test-pod',
+          new Set([PodPhase.RUNNING]),
+          new Set([PodPhase.PENDING])
+        )
+      ).rejects.toThrow(
+        'Pod test-pod is unhealthy with phase status Unknown: network timeout'
+      )
+    })
+
+    it('should not produce empty braces from Error objects', async () => {
+      mockReadNamespacedPod.mockRejectedValue(
+        new Error('socket hang up')
+      )
+
+      try {
+        await waitForPodPhases(
+          'test-pod',
+          new Set([PodPhase.RUNNING]),
+          new Set([PodPhase.PENDING])
+        )
+        fail('Expected waitForPodPhases to throw')
+      } catch (error) {
+        const msg = (error as Error).message
+        expect(msg).not.toContain('{}')
+        expect(msg).toContain('socket hang up')
+      }
+    })
+  })
+})

--- a/packages/k8s/tests/error-serialization-test.ts
+++ b/packages/k8s/tests/error-serialization-test.ts
@@ -1,5 +1,3 @@
-import { WritableStreamBuffer } from 'stream-buffers'
-
 const mockExec = jest.fn()
 const mockReadNamespacedPod = jest.fn()
 const mockReadNamespacedJob = jest.fn()
@@ -89,9 +87,9 @@ describe('error serialization', () => {
 
       await expect(
         execCpToPod('test-pod', '/tmp/src', '/workspace')
-      ).rejects.toThrow(
-        expect.not.objectContaining({ message: expect.stringContaining('{}') })
-      )
+      ).rejects.toMatchObject({
+        message: expect.not.stringContaining('{}')
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Fix error serialization in 4 catch blocks where `JSON.stringify(error)` produces `"{}"` instead of the actual error message, making thrown errors useless for debugging.

## Problem

JavaScript's `Error` object stores its `message` and `stack` properties as **non-enumerable** properties. `JSON.stringify()` only serializes enumerable properties, so:

```js
const err = new Error("connection refused");
JSON.stringify(err);  // → "{}"
```

This means every error thrown from these 4 locations produces a message like:

```
cpToPod failed after 30 attempts: {}
execCpFromPod failed after 30 attempts: {}
job my-job has failed: {}
Pod my-pod is unhealthy with phase status Failed: {}
```

The actual error information — the message explaining *what* failed and *why* — is silently discarded. When these errors surface in CI logs, operators see that something failed 30 times but have no idea what the underlying error was. This makes debugging pod copy failures, job failures, and unhealthy pod conditions significantly harder than it needs to be.

### Affected locations

All 4 are in `packages/k8s/src/k8s/index.ts`:

| Function | Line | Context |
|---|---|---|
| `execCpToPod` | 433 | Thrown after 30 failed attempts to copy files into the job pod |
| `execCpFromPod` | 530 | Thrown after 30 failed attempts to copy files out of the job pod |
| `waitForJobToComplete` | 577 | Thrown when the K8s Job API watch reports a failure |
| `waitForPodPhases` | 700 | Thrown when a pod enters an unhealthy phase (Failed, Unknown) |

These are all terminal error paths — the error is thrown up to the GitHub Actions runner, which logs it and fails the job. The error message is the **only** diagnostic information available to the workflow author.

## Solution

Replace `JSON.stringify(error)` with:

```typescript
error instanceof Error ? error.message : String(error)
```

This handles both cases:
- **`Error` objects** (the common case): extracts `.message` directly, producing readable output like `"connection refused"`, `"ETIMEOUT"`, `"404 Not Found"`.
- **Non-Error throwables** (rare but possible — strings, numbers, objects thrown by dependencies): uses `String()` coercion, which calls `.toString()` and always produces something readable. This is strictly better than `JSON.stringify()` even for non-Error objects since `String({})` → `"[object Object]"` while `JSON.stringify({custom: "data"})` would work — but the Error case is what matters in practice.

### After this fix

```
cpToPod failed after 30 attempts: connect ECONNREFUSED 10.0.0.5:443
execCpFromPod failed after 30 attempts: ETIMEOUT
job my-job has failed: Job reached backoff limit
Pod my-pod is unhealthy with phase status Failed: containers with unready status: [main]
```

### What this does NOT change

- Error handling flow — same catch blocks, same retry counts, same throw-up-the-stack behavior
- The `core.debug()` calls earlier in each catch block (e.g. line 429: `` core.debug(`cpToPod: Attempt ${attempt + 1} failed: ${error}`) ``) — these already use template literal coercion which calls `.toString()` and works correctly. Only the final `throw new Error(...)` messages were broken.
- No new dependencies, no new error types, no behavioral changes

## Files changed

- `packages/k8s/src/k8s/index.ts` — 4 lines changed (identical substitution in each)

## Test plan

- [x] `npm run build` succeeds (tsc + ncc)
- [x] All 22 existing k8s-utils tests pass
- [x] No remaining `JSON.stringify(error)` in the file
- [x] In production for pytorch/* org that uses the fork https://github.com/jeanschmidt/runner-container-hooks