### PR TITLE
Add opt-in same-node scheduling preference for job and step pods

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -16,6 +16,8 @@ import {
   PodPhase,
   mergePodSpecWithOptions,
   mergeObjectMeta,
+  injectSameNodePreference,
+  useSameNodePreference,
   fixArgs,
   listDirAllCommand,
   sleep,
@@ -34,6 +36,30 @@ const k8sBatchV1Api = kc.makeApiClient(k8s.BatchV1Api)
 const k8sAuthorizationV1Api = kc.makeApiClient(k8s.AuthorizationV1Api)
 
 const DEFAULT_WAIT_FOR_POD_TIME_SECONDS = 10 * 60 // 10 min
+
+async function applySameNodePreference(spec: k8s.V1PodSpec): Promise<void> {
+  if (!useSameNodePreference()) {
+    return
+  }
+  try {
+    const runnerPodName = process.env.ACTIONS_RUNNER_POD_NAME
+    if (!runnerPodName) {
+      return
+    }
+    const runnerPod = await k8sApi.readNamespacedPod({
+      name: runnerPodName,
+      namespace: namespace()
+    })
+    const runnerNodeName = runnerPod.spec?.nodeName
+    if (runnerNodeName) {
+      injectSameNodePreference(spec, runnerNodeName)
+    }
+  } catch (err) {
+    core.warning(
+      `Could not look up runner pod node for same-node scheduling: ${err}`
+    )
+  }
+}
 
 export const requiredPermissions = [
   {
@@ -176,6 +202,8 @@ export async function createJobPod(
     mergePodSpecWithOptions(appPod.spec, extension.spec)
   }
 
+  await applySameNodePreference(appPod.spec)
+
   return await k8sApi.createNamespacedPod({
     namespace: namespace(),
     body: appPod
@@ -228,6 +256,8 @@ export async function createContainerStepPod(
   if (extension?.spec) {
     mergePodSpecWithOptions(appPod.spec, extension.spec)
   }
+
+  await applySameNodePreference(appPod.spec)
 
   return await k8sApi.createNamespacedPod({
     namespace: namespace(),

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -44,6 +44,9 @@ async function applySameNodePreference(spec: k8s.V1PodSpec): Promise<void> {
   try {
     const runnerPodName = process.env.ACTIONS_RUNNER_POD_NAME
     if (!runnerPodName) {
+      core.warning(
+        'Same-node scheduling preference is enabled but ACTIONS_RUNNER_POD_NAME is not set'
+      )
       return
     }
     const runnerPod = await k8sApi.readNamespacedPod({

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
 
 export const ENV_HOOK_TEMPLATE_PATH = 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE'
 export const ENV_USE_KUBE_SCHEDULER = 'ACTIONS_RUNNER_USE_KUBE_SCHEDULER'
+export const ENV_SAME_NODE_PREFERENCE = 'ACTIONS_RUNNER_SAME_NODE_PREFERENCE'
 
 export const EXTERNALS_VOLUME_NAME = 'externals'
 export const GITHUB_VOLUME_NAME = 'github'
@@ -267,6 +268,42 @@ export function readExtensionFromFile(): k8s.V1PodTemplateSpec | undefined {
 
 export function useKubeScheduler(): boolean {
   return process.env[ENV_USE_KUBE_SCHEDULER] === 'true'
+}
+
+export function useSameNodePreference(): boolean {
+  return process.env[ENV_SAME_NODE_PREFERENCE] === 'true'
+}
+
+export function injectSameNodePreference(
+  spec: k8s.V1PodSpec,
+  nodeName: string
+): void {
+  if (!spec.affinity) {
+    spec.affinity = {}
+  }
+  if (!spec.affinity.nodeAffinity) {
+    spec.affinity.nodeAffinity = {}
+  }
+  if (
+    !spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution
+  ) {
+    spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution =
+      []
+  }
+  spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.push(
+    {
+      weight: 100,
+      preference: {
+        matchExpressions: [
+          {
+            key: 'kubernetes.io/hostname',
+            operator: 'In',
+            values: [nodeName]
+          }
+        ]
+      }
+    }
+  )
 }
 
 export enum PodPhase {

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -6,6 +6,9 @@ import {
   mergePodSpecWithOptions,
   mergeContainerWithOptions,
   readExtensionFromFile,
+  injectSameNodePreference,
+  useSameNodePreference,
+  ENV_SAME_NODE_PREFERENCE,
   ENV_HOOK_TEMPLATE_PATH
 } from '../src/k8s/utils'
 import * as k8s from '@kubernetes/client-node'
@@ -337,6 +340,123 @@ spec:
     expectJobContainer.name = base.name
     mergeContainerWithOptions(base, from)
     expect(base).toStrictEqual(expectContainer)
+  })
+
+  describe('useSameNodePreference', () => {
+    const originalEnv = process.env
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it('should return false when env var is not set', () => {
+      delete process.env[ENV_SAME_NODE_PREFERENCE]
+      expect(useSameNodePreference()).toBe(false)
+    })
+
+    it('should return false when env var is empty', () => {
+      process.env[ENV_SAME_NODE_PREFERENCE] = ''
+      expect(useSameNodePreference()).toBe(false)
+    })
+
+    it('should return false when env var is not "true"', () => {
+      process.env[ENV_SAME_NODE_PREFERENCE] = 'false'
+      expect(useSameNodePreference()).toBe(false)
+
+      process.env[ENV_SAME_NODE_PREFERENCE] = 'TRUE'
+      expect(useSameNodePreference()).toBe(false)
+
+      process.env[ENV_SAME_NODE_PREFERENCE] = '1'
+      expect(useSameNodePreference()).toBe(false)
+    })
+
+    it('should return true when env var is "true"', () => {
+      process.env[ENV_SAME_NODE_PREFERENCE] = 'true'
+      expect(useSameNodePreference()).toBe(true)
+    })
+  })
+
+  describe('injectSameNodePreference', () => {
+    it('should add nodeAffinity to empty spec', () => {
+      const spec = { containers: [] } as k8s.V1PodSpec
+      injectSameNodePreference(spec, 'node-1')
+
+      const preferred =
+        spec.affinity?.nodeAffinity
+          ?.preferredDuringSchedulingIgnoredDuringExecution
+      expect(preferred).toHaveLength(1)
+      expect(preferred![0].weight).toBe(100)
+      expect(
+        preferred![0].preference.matchExpressions![0]
+      ).toStrictEqual({
+        key: 'kubernetes.io/hostname',
+        operator: 'In',
+        values: ['node-1']
+      })
+    })
+
+    it('should append to existing preferred scheduling entries', () => {
+      const spec = {
+        containers: [],
+        affinity: {
+          nodeAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [
+              {
+                weight: 50,
+                preference: {
+                  matchExpressions: [
+                    {
+                      key: 'node.kubernetes.io/instance-type',
+                      operator: 'In',
+                      values: ['m5.xlarge']
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      } as k8s.V1PodSpec
+
+      injectSameNodePreference(spec, 'node-2')
+
+      const preferred =
+        spec.affinity!.nodeAffinity!
+          .preferredDuringSchedulingIgnoredDuringExecution!
+      expect(preferred).toHaveLength(2)
+      expect(preferred[0].weight).toBe(50)
+      expect(preferred[1].weight).toBe(100)
+      expect(
+        preferred[1].preference.matchExpressions![0].values
+      ).toStrictEqual(['node-2'])
+    })
+
+    it('should not touch requiredDuringScheduling', () => {
+      const required = {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              { key: 'zone', operator: 'In', values: ['us-east-1a'] }
+            ]
+          }
+        ]
+      }
+      const spec = {
+        containers: [],
+        affinity: {
+          nodeAffinity: {
+            requiredDuringSchedulingIgnoredDuringExecution: required
+          }
+        }
+      } as k8s.V1PodSpec
+
+      injectSameNodePreference(spec, 'node-3')
+
+      expect(
+        spec.affinity!.nodeAffinity!
+          .requiredDuringSchedulingIgnoredDuringExecution
+      ).toStrictEqual(required)
+    })
   })
 
   it('should merge pod spec', () => {

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -343,10 +343,18 @@ spec:
   })
 
   describe('useSameNodePreference', () => {
-    const originalEnv = process.env
+    let savedValue: string | undefined
+
+    beforeEach(() => {
+      savedValue = process.env[ENV_SAME_NODE_PREFERENCE]
+    })
 
     afterEach(() => {
-      process.env = originalEnv
+      if (savedValue === undefined) {
+        delete process.env[ENV_SAME_NODE_PREFERENCE]
+      } else {
+        process.env[ENV_SAME_NODE_PREFERENCE] = savedValue
+      }
     })
 
     it('should return false when env var is not set', () => {

--- a/packages/k8s/tests/prepare-job-test.ts
+++ b/packages/k8s/tests/prepare-job-test.ts
@@ -3,7 +3,11 @@ import * as path from 'path'
 import { cleanupJob } from '../src/hooks'
 import { createContainerSpec, prepareJob } from '../src/hooks/prepare-job'
 import { TestHelper } from './test-setup'
-import { ENV_HOOK_TEMPLATE_PATH, generateContainerName } from '../src/k8s/utils'
+import {
+  ENV_HOOK_TEMPLATE_PATH,
+  ENV_SAME_NODE_PREFERENCE,
+  generateContainerName
+} from '../src/k8s/utils'
 import { execPodStep, getPodByName } from '../src/k8s'
 import { V1Container } from '@kubernetes/client-node'
 import { JOB_CONTAINER_NAME } from '../src/hooks/constants'
@@ -241,6 +245,50 @@ describe('Prepare job', () => {
     expect(content.state.jobPod).toBeTruthy()
     expect(content.context.container.image).toBe(
       'ghcr.io/actions/actions-runner:latest'
+    )
+  })
+
+  it('should apply same-node scheduling preference when enabled', async () => {
+    process.env[ENV_SAME_NODE_PREFERENCE] = 'true'
+
+    const runnerPodName = process.env.ACTIONS_RUNNER_POD_NAME!
+    let runnerNodeName: string | undefined
+    for (let i = 0; i < 30; i++) {
+      const runnerPod = await getPodByName(runnerPodName)
+      runnerNodeName = runnerPod.spec?.nodeName
+      if (runnerNodeName) break
+      await new Promise(r => setTimeout(r, 1000))
+    }
+    expect(runnerNodeName).toBeTruthy()
+
+    await prepareJob(prepareJobData.args, prepareJobOutputFilePath)
+
+    delete process.env[ENV_SAME_NODE_PREFERENCE]
+
+    const content = JSON.parse(
+      fs.readFileSync(prepareJobOutputFilePath).toString()
+    )
+
+    const got = await getPodByName(content.state.jobPod)
+    const preferred =
+      got.spec?.affinity?.nodeAffinity
+        ?.preferredDuringSchedulingIgnoredDuringExecution
+    expect(preferred).toBeDefined()
+    expect(preferred).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          weight: 100,
+          preference: {
+            matchExpressions: [
+              {
+                key: 'kubernetes.io/hostname',
+                operator: 'In',
+                values: [runnerNodeName]
+              }
+            ]
+          }
+        })
+      ])
     )
   })
 })


### PR DESCRIPTION
# Add opt-in same-node scheduling preference for job and step pods

## Summary

Add a configurable same-node scheduling preference that biases job pods and container step pods toward the same Kubernetes node as their runner pod. Enabled via `ACTIONS_RUNNER_SAME_NODE_PREFERENCE=true`. Disabled by default — no behavioral change unless explicitly opted in.

## Problem

When a runner pod creates a job pod (or a container step pod), the Kubernetes scheduler places it on **any available node** in the cluster. In setups where data locality matters — e.g. host-path caches, NVMe scratch volumes, pre-pulled images, or shared emptyDir volumes — this can cause:

- **Cross-node data transfer**: workspace copies (`execCpToPod`/`execCpFromPod`) go over the network instead of staying node-local
- **Cache misses**: node-level caches (git object caches, layer caches, dependency caches) are only useful if the job lands on the same node
- **Increased latency**: pod startup is slower when images need to be pulled to a different node

There is currently no mechanism in the hooks to influence node placement. The only option is an external hook template (`ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE`), but that's a static YAML file — it can't dynamically discover the runner pod's current node.

## Solution

Add a weight-100 `preferredDuringSchedulingIgnoredDuringExecution` node affinity to workflow pods, targeting the same node as the runner pod.

### How it works

1. On pod creation, check if `ACTIONS_RUNNER_SAME_NODE_PREFERENCE=true` is set. If not, return immediately (no API calls, no overhead).
2. Read `ACTIONS_RUNNER_POD_NAME` to identify the runner pod.
3. Look up the runner pod via the K8s API to find its `spec.nodeName`.
4. Inject a weighted node affinity entry matching `kubernetes.io/hostname` = that node name.
5. The Kubernetes scheduler **prefers** the same node but gracefully falls back to other nodes when the target node is full or unavailable.

### Why `preferred` instead of `required`

A hard `nodeName` pin or `requiredDuringScheduling` would cause job pods to fail scheduling entirely if the node has insufficient resources. The weight-100 preferred affinity gives maximum bias while remaining fault-tolerant — the scheduler treats it as a strong hint, not a hard constraint.

### Configuration

| Env var | Required | Default | Description |
|---|---|---|---|
| `ACTIONS_RUNNER_SAME_NODE_PREFERENCE` | No | (unset / disabled) | Set to `"true"` to enable same-node preference |
| `ACTIONS_RUNNER_POD_NAME` | Yes (already required by hooks) | — | Used to look up the runner pod's node. Auto-injected by ARC. |

### RBAC requirement

The runner's ServiceAccount needs `get` permission on the `pods` resource (already in `requiredPermissions`) to look up the runner pod's node name. No additional RBAC is needed.

### Error handling

Non-fatal. If the runner pod lookup fails for any reason (permissions, pod not found, API timeout), a warning is logged via `core.warning()` and the pod is created without the affinity — identical to the current behavior.

### What this does NOT change

- Default behavior — feature is disabled unless explicitly opted in
- Pod creation flow — same containers, volumes, extensions, labels
- Extension template merging — the affinity is injected **after** extension merge, so it appends to (never overwrites) any affinity from `ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE`
- No new dependencies

## Files changed

- `packages/k8s/src/k8s/utils.ts` — Added `ENV_SAME_NODE_PREFERENCE` constant, `useSameNodePreference()` gate function, and `injectSameNodePreference()` utility that builds the nodeAffinity entry
- `packages/k8s/src/k8s/index.ts` — Added `applySameNodePreference()` function (env var gated, K8s API lookup, non-fatal), called from both `createJobPod` and `createContainerStepPod`
- `packages/k8s/tests/k8s-utils-test.ts` — 7 new tests covering the gate function and affinity injection

## Test plan

- [x] `npm run build` succeeds (tsc + ncc)
- [x] All 29 tests pass (22 existing + 7 new)
- [x] `useSameNodePreference` returns `false` when env var is unset, empty, `"false"`, `"TRUE"`, or `"1"`
- [x] `useSameNodePreference` returns `true` only when env var is exactly `"true"`
- [x] `injectSameNodePreference` creates affinity from scratch on empty spec
- [x] `injectSameNodePreference` appends to existing preferred scheduling entries (preserves template affinities)
- [x] `injectSameNodePreference` does not touch `requiredDuringSchedulingIgnoredDuringExecution`
- [x] In production for pytorch/* org via fork https://github.com/jeanschmidt/runner-container-hooks