### PR TITLE
feat(k8s): surface pod Warning events on waitForPodPhases timeout

### DIFF
--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -784,9 +784,43 @@ export async function waitForPodPhases(
       await backOffManager.backOff()
     }
   } catch (error) {
+    const warningEvents = await getPodWarningEvents(podName)
+    const eventsSuffix = warningEvents ? `; events: ${warningEvents}` : ''
     throw new Error(
-      `Pod ${podName} is unhealthy with phase status ${phase}: ${formatError(error)}`
+      `Pod ${podName} is unhealthy with phase status ${phase}: ${formatError(error)}${eventsSuffix}`
     )
+  }
+}
+
+// Best-effort: surface the most recent Warning events for a pod
+// (FailedScheduling, FailedMount, etc.) that explain why it never reached a
+// healthy phase. These live on the Event resource, not the pod object, and the
+// ephemeral workflow pod is usually pruned before an operator can
+// `kubectl describe` it — so without this the diagnostic is lost. Never throws:
+// it is diagnostic-only and must not shadow the original failure. Reading
+// events needs `events: list`; this is intentionally NOT added to
+// requiredPermissions (that would hard-fail prepareJob for existing
+// least-privilege deployments), so a 403 here is swallowed and simply yields no
+// extra detail.
+async function getPodWarningEvents(podName: string): Promise<string> {
+  try {
+    const { items } = await k8sApi.listNamespacedEvent({
+      namespace: namespace(),
+      fieldSelector: `involvedObject.name=${podName},type=Warning`
+    })
+    return (items ?? [])
+      .map(e => ({
+        reason: e.reason,
+        message: e.message,
+        when: new Date(e.lastTimestamp ?? e.eventTime ?? 0).getTime()
+      }))
+      .sort((a, b) => b.when - a.when)
+      .slice(0, 3)
+      .map(e => `[${e.reason}] ${e.message}`)
+      .join('; ')
+  } catch (err) {
+    core.debug(`Could not list events for pod ${podName}: ${formatError(err)}`)
+    return ''
   }
 }
 

--- a/packages/k8s/tests/pod-events-test.ts
+++ b/packages/k8s/tests/pod-events-test.ts
@@ -1,0 +1,171 @@
+const mockReadNamespacedPod = jest.fn()
+const mockListNamespacedEvent = jest.fn()
+
+jest.mock('@kubernetes/client-node', () => {
+  return {
+    KubeConfig: jest.fn().mockImplementation(() => ({
+      loadFromDefault: jest.fn(),
+      makeApiClient: jest.fn().mockImplementation(ApiClass => {
+        const name = ApiClass?.name || ApiClass?.toString() || ''
+        if (name.includes('Batch')) {
+          return { readNamespacedJob: jest.fn() }
+        }
+        if (name.includes('Authorization')) {
+          return { createSelfSubjectAccessReview: jest.fn() }
+        }
+        return {
+          readNamespacedPod: mockReadNamespacedPod,
+          listNamespacedEvent: mockListNamespacedEvent
+        }
+      }),
+      getContexts: jest.fn().mockReturnValue([{ namespace: 'test-namespace' }])
+    })),
+    Exec: jest.fn().mockImplementation(() => ({ exec: jest.fn() })),
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    CoreV1Api: class CoreV1Api {},
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    BatchV1Api: class BatchV1Api {},
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    AuthorizationV1Api: class AuthorizationV1Api {},
+    Log: jest.fn()
+  }
+})
+
+jest.mock('tar-fs', () => ({
+  default: {
+    pack: jest.fn().mockReturnValue({ pipe: jest.fn() }),
+    extract: jest.fn().mockReturnValue({
+      on: jest.fn(),
+      pipe: jest.fn()
+    })
+  },
+  __esModule: true
+}))
+
+import { waitForPodPhases } from '../src/k8s'
+import { PodPhase } from '../src/k8s/utils'
+
+// awaiting RUNNING / backing-off PENDING mirrors the real prepare-job call.
+// A pod reported in any other phase falls straight into the unhealthy-throw
+// path, which is the catch block that enriches the error with Warning events.
+const awaitingPhases = (): Set<PodPhase> => new Set([PodPhase.RUNNING])
+const backOffPhases = (): Set<PodPhase> => new Set([PodPhase.PENDING])
+
+describe('waitForPodPhases Warning event enrichment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE'] = 'test-namespace'
+  })
+
+  afterEach(() => {
+    delete process.env['ACTIONS_RUNNER_KUBERNETES_NAMESPACE']
+  })
+
+  it('appends recent Warning events to the thrown error', async () => {
+    mockReadNamespacedPod.mockResolvedValue({ status: { phase: 'Failed' } })
+    mockListNamespacedEvent.mockResolvedValue({
+      items: [
+        {
+          reason: 'FailedScheduling',
+          message: '0/3 nodes are available: 3 Too many pods.',
+          lastTimestamp: new Date('2026-06-05T10:00:00Z'),
+          type: 'Warning'
+        }
+      ]
+    })
+
+    await expect(
+      waitForPodPhases('test-pod', awaitingPhases(), backOffPhases())
+    ).rejects.toThrow(
+      'events: [FailedScheduling] 0/3 nodes are available: 3 Too many pods.'
+    )
+  })
+
+  it('queries Warning events scoped to the pod in the right namespace', async () => {
+    mockReadNamespacedPod.mockResolvedValue({ status: { phase: 'Failed' } })
+    mockListNamespacedEvent.mockResolvedValue({ items: [] })
+
+    await expect(
+      waitForPodPhases('test-pod', awaitingPhases(), backOffPhases())
+    ).rejects.toThrow(/unhealthy with phase status Failed/)
+
+    expect(mockListNamespacedEvent).toHaveBeenCalledWith({
+      namespace: 'test-namespace',
+      fieldSelector: 'involvedObject.name=test-pod,type=Warning'
+    })
+  })
+
+  it('keeps only the 3 most recent events, newest first', async () => {
+    mockReadNamespacedPod.mockResolvedValue({ status: { phase: 'Failed' } })
+    mockListNamespacedEvent.mockResolvedValue({
+      items: [
+        {
+          reason: 'Oldest',
+          message: 'm0',
+          lastTimestamp: new Date('2026-06-05T10:00:00Z')
+        },
+        {
+          reason: 'Newest',
+          message: 'm3',
+          lastTimestamp: new Date('2026-06-05T10:03:00Z')
+        },
+        {
+          reason: 'Middle',
+          message: 'm1',
+          // exercise the eventTime fallback when lastTimestamp is absent
+          eventTime: new Date('2026-06-05T10:01:00Z')
+        },
+        {
+          reason: 'Later',
+          message: 'm2',
+          lastTimestamp: new Date('2026-06-05T10:02:00Z')
+        }
+      ]
+    })
+
+    let message = ''
+    try {
+      await waitForPodPhases('test-pod', awaitingPhases(), backOffPhases())
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain('events: [Newest] m3; [Later] m2; [Middle] m1')
+    expect(message).not.toContain('Oldest')
+  })
+
+  it('does not append an events section when there are none', async () => {
+    mockReadNamespacedPod.mockResolvedValue({ status: { phase: 'Failed' } })
+    mockListNamespacedEvent.mockResolvedValue({ items: [] })
+
+    let message = ''
+    try {
+      await waitForPodPhases('test-pod', awaitingPhases(), backOffPhases())
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain('unhealthy with phase status Failed')
+    expect(message).not.toContain('events:')
+  })
+
+  it('is best-effort: a failed event lookup never shadows the original error', async () => {
+    mockReadNamespacedPod.mockRejectedValue(new Error('network timeout'))
+    mockListNamespacedEvent.mockRejectedValue(
+      new Error('events is forbidden: User cannot list events')
+    )
+
+    let message = ''
+    try {
+      await waitForPodPhases('test-pod', awaitingPhases(), backOffPhases())
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain(
+      'Pod test-pod is unhealthy with phase status Unknown: network timeout'
+    )
+    expect(message).not.toContain('events:')
+    expect(message).not.toContain('forbidden')
+  })
+})


### PR DESCRIPTION
## Summary

When a workflow pod never reaches `Running` for a reason that lives on the K8s **Event** resource (`FailedScheduling: Too many pods` / `Insufficient cpu`, untolerated taints, `FailedMount`, …) rather than on the pod object, `waitForPodPhases` surfaced only a generic timeout. The ephemeral pod is usually pruned before an operator can `kubectl describe` it, so the diagnostic was lost.

It now makes a **best-effort** fetch of the pod's most recent `Warning` events in its catch path and appends up to the 3 newest to the thrown error:

```
Pod foo is unhealthy with phase status Pending: backoff timeout; events: [FailedScheduling] 0/3 nodes are available: 3 Too many pods.
```

The lookup **never throws** — it must not shadow the original failure.

## ⚠️ Permissions — needs a maintainer call

Reading events needs `events: list`. I **intentionally did not add it to `requiredPermissions`**: `isAuthPermissionsOK()` hard-requires every entry, so adding it would make `prepareJob` fail for every existing least-privilege deployment whose Role lacks events. A 403 here is therefore swallowed and simply yields no extra detail (non-breaking).

Trade-off: to actually benefit, the runner's Role needs `events: get,list` — a companion change in the actions-runner-controller chart (separate repo). Happy to instead add it to `requiredPermissions` if you'd prefer the contract be explicit and coordinate the chart update.

## Scope

Third piece of the k8s error-surfacing work after #341 and #364 (both merged). Complements #336, which reads `containerStatuses[].state.waiting.{reason,message}` — a different resource (the image-pull case). No overlap with #370.

## Tests

New `pod-events-test.ts` (5 cases): events appended; correct namespace + `fieldSelector`; top-3 newest-first (incl. the `eventTime` fallback); no-events → no suffix; and a failed event lookup never shadows the original error. All unit suites pass; `lint` / `format-check` / `tsc + ncc` clean. (The 5 cluster-dependent integration suites are unchanged and fail only for lack of a live cluster — same as `main`.)

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
