### PR TITLE
Create parent dir before writing entry-point scripts

### DIFF
--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@kubernetes/client-node'
 import * as fs from 'fs'
+import * as path from 'path'
 import * as yaml from 'js-yaml'
 import * as core from '@actions/core'
 import { v1 as uuidv4 } from 'uuid'
@@ -45,8 +46,13 @@ cp -R /__w/_temp/_github_workflow /github/workflow
 mkdir -p ${mountDirs}
 `
 
+  const runnerTemp = process.env.RUNNER_TEMP
+  if (!runnerTemp) {
+    throw new Error('RUNNER_TEMP is not set')
+  }
   const filename = `${uuidv4()}.sh`
-  const entryPointPath = `${process.env.RUNNER_TEMP}/${filename}`
+  const entryPointPath = `${runnerTemp}/${filename}`
+  fs.mkdirSync(path.dirname(entryPointPath), { recursive: true })
   fs.writeFileSync(entryPointPath, content)
   return {
     containerPath: `/__w/_temp/${filename}`,
@@ -80,8 +86,13 @@ exec ${environmentPrefix} ${entryPoint} ${
     entryPointArgs?.length ? entryPointArgs.join(' ') : ''
   }
 `
+  const runnerTemp = process.env.RUNNER_TEMP
+  if (!runnerTemp) {
+    throw new Error('RUNNER_TEMP is not set')
+  }
   const filename = `${uuidv4()}.sh`
-  const entryPointPath = `${process.env.RUNNER_TEMP}/${filename}`
+  const entryPointPath = `${runnerTemp}/${filename}`
+  fs.mkdirSync(path.dirname(entryPointPath), { recursive: true })
   fs.writeFileSync(entryPointPath, content)
   return {
     containerPath: `/__w/_temp/${filename}`,
@@ -117,6 +128,7 @@ exec ${environmentPrefix} ${entryPoint} ${
   const filename = `${uuidv4()}.sh`
   const entryPointPath = `${dst}/${filename}`
   core.debug(`Writing container step script to ${entryPointPath}`)
+  fs.mkdirSync(path.dirname(entryPointPath), { recursive: true })
   fs.writeFileSync(entryPointPath, content)
   return {
     containerPath: `/__w/_temp/${filename}`,

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -1,7 +1,11 @@
 ﻿import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import { containerPorts } from '../src/k8s'
 import {
   generateContainerName,
+  prepareJobScript,
+  writeContainerStepScript,
   writeRunScript,
   mergePodSpecWithOptions,
   mergeContainerWithOptions,
@@ -117,6 +121,55 @@ describe('k8s utils', () => {
           SOME_ENV: 'SOME_VALUE'
         }
       )
+      expect(fs.existsSync(runnerPath)).toBe(true)
+    })
+  })
+
+  describe('defensive parent-dir creation', () => {
+    let tempRoot: string
+
+    beforeEach(() => {
+      tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pr05-'))
+    })
+
+    afterEach(() => {
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    })
+
+    it('writeRunScript creates RUNNER_TEMP parent directory when missing', () => {
+      const missingDir = path.join(tempRoot, 'nested', 'runner_temp')
+      expect(fs.existsSync(missingDir)).toBe(false)
+      process.env.RUNNER_TEMP = missingDir
+
+      const { runnerPath } = writeRunScript('/test', 'sh', ['-e', 'script.sh'])
+
+      expect(fs.existsSync(missingDir)).toBe(true)
+      expect(fs.existsSync(runnerPath)).toBe(true)
+    })
+
+    it('prepareJobScript creates RUNNER_TEMP parent directory when missing', () => {
+      const missingDir = path.join(tempRoot, 'nested', 'runner_temp')
+      expect(fs.existsSync(missingDir)).toBe(false)
+      process.env.RUNNER_TEMP = missingDir
+
+      const { runnerPath } = prepareJobScript([])
+
+      expect(fs.existsSync(missingDir)).toBe(true)
+      expect(fs.existsSync(runnerPath)).toBe(true)
+    })
+
+    it('writeContainerStepScript creates dst parent directory when missing', () => {
+      const missingDst = path.join(tempRoot, 'nested', 'step_dst')
+      expect(fs.existsSync(missingDst)).toBe(false)
+
+      const { runnerPath } = writeContainerStepScript(
+        missingDst,
+        '/__w/repo/repo',
+        'sh',
+        ['-e', 'script.sh']
+      )
+
+      expect(fs.existsSync(missingDst)).toBe(true)
       expect(fs.existsSync(runnerPath)).toBe(true)
     })
   })


### PR DESCRIPTION
Create parent dir before writing entry-point scripts

**Impact:** k8s hook users — eliminates a class of indirect ENOENT failures when writing job/run/step entry-point scripts.
**Risk:** low

## What
Defensively `mkdir -p` the parent directory before each `fs.writeFileSync` call that writes an entry-point script in `packages/k8s/src/k8s/utils.ts`, and add an explicit `RUNNER_TEMP` guard to the two writers that depend on it.

## Why
`fs.writeFileSync` throws `ENOENT` when the target file's parent directory does not exist. In normal flows the parent is created early in the job, but cleanup races, custom `RUNNER_TEMP` overrides, and fresh container-step `dst` directories can leave it missing. The resulting `ENOENT` surfaces as a confusing, indirect failure far from the real cause.

## How
- `fs.mkdirSync(path.dirname(entryPointPath), { recursive: true })` immediately before each of the three `writeFileSync` calls. The call is cheap and idempotent.
- The previous behavior of "fail if `RUNNER_TEMP` is unset" relied implicitly on `writeFileSync` rejecting `undefined/<uuid>.sh`. With `mkdirSync` added, that path would silently create a literal `undefined/` directory in the cwd. To preserve the prior failure contract, an explicit `if (!runnerTemp) throw` guard is added at the top of `prepareJobScript` and `writeRunScript`. `writeContainerStepScript` needs no guard because `dst` is a required parameter.

## Changes
- `packages/k8s/src/k8s/utils.ts`:
  - Import `path`.
  - `prepareJobScript`, `writeRunScript`: explicit `RUNNER_TEMP` guard, `mkdirSync(..., { recursive: true })` before write.
  - `writeContainerStepScript`: `mkdirSync(..., { recursive: true })` before write.
- `packages/k8s/tests/k8s-utils-test.ts`: new `defensive parent-dir creation` describe block with one test per writer, each pointing at a non-existent nested directory and asserting both the directory and the script file exist after the call.
