### PR TITLE
k8s: provision /github dirs per step so container uses:/JS actions get event.json

### DIFF
--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -61,7 +61,12 @@ export async function runScriptStep(
     cp -a "$1" "$target"
   ' _ {} "$SRC" "$DST" \\;`,
     // Remove _temp_pre after merging
-    'rm -rf /__w/_temp_pre'
+    'rm -rf /__w/_temp_pre',
+    // Refresh /github from merged temp so uses:/JS-action steps see event.json
+    'mkdir -p /github/home /github/workflow /github/file_commands',
+    'cp -a "$DST/_github_home/." /github/home/ 2>/dev/null || true',
+    'cp -a "$DST/_github_workflow/." /github/workflow/ 2>/dev/null || true',
+    'cp -a "$DST/_runner_file_commands/." /github/file_commands/ 2>/dev/null || true'
   ]
 
   try {


### PR DESCRIPTION
Fixes #330. Also supersedes the prepare-time approach in #300, and relates to #337 / #347 (missing `/github` dirs in novolume).

## Problem

In `kubernetes-novolume` container mode, a containerised `uses:`/JS-action step that reads the event payload via `GITHUB_EVENT_PATH` (`/github/workflow/event.json`) receives an **empty payload** and fails. For example `actions/dependency-review-action` errors with a schema-validation failure:

```
GITHUB_EVENT_PATH /github/workflow/event.json does not exist
##[error][ { "code": "invalid_type", "expected": "object", "received": "undefined", "message": "Required" } ]
```

`run:` steps are unaffected because they operate in `/__w`.

## Root cause

This is the regression described in #330. `/github/{home,workflow}` used to be copied per step in `run-script-step.ts` (added in #287), but #293 ("Reduce the amount of data copied to the workflow pod") replaced that block with a `_temp_pre` → `_temp` merge that only handles `_temp` and no longer copies `_github_home`/`_github_workflow` into `/github/`.

`/github` is otherwise provisioned only by:

- `prepareJobScript` (`utils.ts`) — once, at prepare-job time, and only when the job declares `userMountVolumes`.
- `writeContainerStepScript` (`utils.ts`) — for Docker container action steps.

Plain run-script / JS-action steps never (re)provision `/github`. And simply un-gating `prepareJobScript` (as in #300) is not sufficient: the runner stages `event.json` into `_work/_temp/_github_workflow` **after** prepare-job completes, so a prepare-time copy is empty. It has to happen at step time.

## Fix

Provision `/github/{home,workflow,file_commands}` from the freshly merged `/__w/_temp` inside `runScriptStep`, in the same `execPodStep` that performs the temp merge — i.e. right before the step entrypoint runs. By then `_work/_temp/_github_workflow/event.json` is present, so the action sees the correct payload. It re-syncs each step, so later-arriving context files stay current. This restores the #287 behaviour within the new merge strategy from #293.

## Testing

- `npm run build-all` (ncc bundle builds cleanly).
- Deployed on self-hosted `kubernetes-novolume` runners: verified live that job containers now have `/github/workflow/event.json` populated, and `actions/dependency-review-action` passes where it previously failed.

Happy to adjust placement (e.g. fold into `writeRunScript`) or add coverage if maintainers prefer.
