### PR TITLE
k8s: optionally mount externals from an image volume instead of copying in fs-init

### DIFF
--- a/packages/k8s/README.md
+++ b/packages/k8s/README.md
@@ -33,6 +33,7 @@ rules:
 - Some actions runner env's are expected to be set. These are set automatically by the runner.
     - `RUNNER_WORKSPACE` is expected to be set to the workspace of the runner
     - `GITHUB_WORKSPACE` is expected to be set to the workspace of the job
+- (Optional) The `ACTIONS_RUNNER_K8S_EXTERNALS_FROM_IMAGE` env can be set to `true` to mount the runner's externals directly from an [image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/) (the runner image, taken from `ACTIONS_RUNNER_IMAGE`) instead of copying them into an `emptyDir` in the `fs-init` init container on every job. This removes the per-job copy of the externals and reduces job pod startup time. It requires the `ImageVolume` feature gate, which is enabled by default in Kubernetes 1.35+; on clusters where it is unavailable the API server drops the volume and jobs fail, so leave it unset (the default) unless your cluster supports it.
 
 
 ## Limitations

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -18,7 +18,7 @@ import {
   execPodStep
 } from '../k8s'
 import {
-  CONTAINER_VOLUMES,
+  containerVolumes,
   DEFAULT_CONTAINER_ENTRY_POINT,
   DEFAULT_CONTAINER_ENTRY_POINT_ARGS,
   formatError,
@@ -284,7 +284,7 @@ export function createContainerSpec(
     })
   }
 
-  podContainer.volumeMounts = CONTAINER_VOLUMES
+  podContainer.volumeMounts = containerVolumes()
 
   if (!extension) {
     return podContainer

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -13,7 +13,7 @@ import {
   waitForPodPhases
 } from '../k8s'
 import {
-  CONTAINER_VOLUMES,
+  containerVolumes,
   formatError,
   mergeContainerWithOptions,
   PodPhase,
@@ -137,7 +137,7 @@ function createContainerSpec(
   podContainer.command = ['tail']
   podContainer.args = DEFAULT_CONTAINER_ENTRY_POINT_ARGS
 
-  podContainer.volumeMounts = CONTAINER_VOLUMES
+  podContainer.volumeMounts = containerVolumes()
 
   if (!extension) {
     return podContainer

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -22,7 +22,10 @@ import {
   sleep,
   EXTERNALS_VOLUME_NAME,
   GITHUB_VOLUME_NAME,
-  WORK_VOLUME
+  WORK_VOLUME,
+  externalsFromImage,
+  externalsVolume,
+  runnerImage
 } from './utils'
 import * as shlex from 'shlex'
 import { parsePositiveMsEnv, WebSocketHeartbeat } from './heartbeat'
@@ -105,12 +108,14 @@ export async function createJobPod(
   const githubWorkspace = process.env.GITHUB_WORKSPACE
   const workingDirPath = githubWorkspace?.split('/').slice(-2).join('/') ?? ''
 
-  const initCommands = [
-    'mkdir -p /mnt/externals',
-    'mkdir -p /mnt/work',
-    'mkdir -p /mnt/github',
-    'mv /home/runner/externals/* /mnt/externals/'
-  ]
+  const initCommands = ['mkdir -p /mnt/work', 'mkdir -p /mnt/github']
+
+  if (!externalsFromImage()) {
+    initCommands.push(
+      'mkdir -p /mnt/externals',
+      'mv /home/runner/externals/* /mnt/externals/'
+    )
+  }
 
   if (workingDirPath) {
     initCommands.push(`mkdir -p /mnt/work/${workingDirPath}`)
@@ -119,19 +124,21 @@ export async function createJobPod(
   appPod.spec.initContainers = [
     {
       name: 'fs-init',
-      image:
-        process.env.ACTIONS_RUNNER_IMAGE ||
-        'ghcr.io/actions/actions-runner:latest',
+      image: runnerImage(),
       command: ['sh', '-c', initCommands.join(' && ')],
       securityContext: {
         runAsGroup: 1001,
         runAsUser: 1001
       },
       volumeMounts: [
-        {
-          name: EXTERNALS_VOLUME_NAME,
-          mountPath: '/mnt/externals'
-        },
+        ...(externalsFromImage()
+          ? []
+          : [
+              {
+                name: EXTERNALS_VOLUME_NAME,
+                mountPath: '/mnt/externals'
+              }
+            ]),
         {
           name: WORK_VOLUME,
           mountPath: '/mnt/work'
@@ -147,10 +154,7 @@ export async function createJobPod(
   appPod.spec.restartPolicy = 'Never'
 
   appPod.spec.volumes = [
-    {
-      name: EXTERNALS_VOLUME_NAME,
-      emptyDir: {}
-    },
+    externalsVolume(),
     {
       name: GITHUB_VOLUME_NAME,
       emptyDir: {}
@@ -210,10 +214,7 @@ export async function createContainerStepPod(
   appPod.spec.restartPolicy = 'Never'
 
   appPod.spec.volumes = [
-    {
-      name: EXTERNALS_VOLUME_NAME,
-      emptyDir: {}
-    },
+    externalsVolume(),
     {
       name: GITHUB_VOLUME_NAME,
       emptyDir: {}

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -12,25 +12,40 @@ export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
 
 export const ENV_HOOK_TEMPLATE_PATH = 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE'
 export const ENV_USE_KUBE_SCHEDULER = 'ACTIONS_RUNNER_USE_KUBE_SCHEDULER'
+export const ENV_EXTERNALS_FROM_IMAGE =
+  'ACTIONS_RUNNER_K8S_EXTERNALS_FROM_IMAGE'
+export const ENV_RUNNER_IMAGE = 'ACTIONS_RUNNER_IMAGE'
+export const DEFAULT_RUNNER_IMAGE = 'ghcr.io/actions/actions-runner:latest'
 
 export const EXTERNALS_VOLUME_NAME = 'externals'
 export const GITHUB_VOLUME_NAME = 'github'
 export const WORK_VOLUME = 'work'
 
-export const CONTAINER_VOLUMES: k8s.V1VolumeMount[] = [
-  {
-    name: EXTERNALS_VOLUME_NAME,
-    mountPath: '/__e'
-  },
-  {
-    name: WORK_VOLUME,
-    mountPath: '/__w'
-  },
-  {
-    name: GITHUB_VOLUME_NAME,
-    mountPath: '/github'
-  }
-]
+export function containerVolumes(): k8s.V1VolumeMount[] {
+  const externals: k8s.V1VolumeMount = externalsFromImage()
+    ? {
+        name: EXTERNALS_VOLUME_NAME,
+        mountPath: '/__e',
+        subPath: 'home/runner/externals',
+        readOnly: true
+      }
+    : {
+        name: EXTERNALS_VOLUME_NAME,
+        mountPath: '/__e'
+      }
+
+  return [
+    externals,
+    {
+      name: WORK_VOLUME,
+      mountPath: '/__w'
+    },
+    {
+      name: GITHUB_VOLUME_NAME,
+      mountPath: '/github'
+    }
+  ]
+}
 
 export function prepareJobScript(userVolumeMounts: Mount[]): {
   containerPath: string
@@ -267,6 +282,30 @@ export function readExtensionFromFile(): k8s.V1PodTemplateSpec | undefined {
 
 export function useKubeScheduler(): boolean {
   return process.env[ENV_USE_KUBE_SCHEDULER] === 'true'
+}
+
+export function externalsFromImage(): boolean {
+  return process.env[ENV_EXTERNALS_FROM_IMAGE] === 'true'
+}
+
+export function runnerImage(): string {
+  return process.env[ENV_RUNNER_IMAGE] || DEFAULT_RUNNER_IMAGE
+}
+
+export function externalsVolume(): k8s.V1Volume {
+  if (externalsFromImage()) {
+    return {
+      name: EXTERNALS_VOLUME_NAME,
+      image: {
+        reference: runnerImage(),
+        pullPolicy: 'IfNotPresent'
+      }
+    }
+  }
+  return {
+    name: EXTERNALS_VOLUME_NAME,
+    emptyDir: {}
+  }
 }
 
 export enum PodPhase {


### PR DESCRIPTION
## What

Adds an opt-in `ACTIONS_RUNNER_K8S_EXTERNALS_FROM_IMAGE=true` that mounts the runner's externals directly from an [image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/) (the runner image, from `ACTIONS_RUNNER_IMAGE`) instead of copying them into an `emptyDir` in the `fs-init` init container on every job.

When enabled:
- The externals volume becomes an `image:` volume referencing `ACTIONS_RUNNER_IMAGE`, mounted **read-only** at `/__e` via `subPath: home/runner/externals`.
- `fs-init` no longer `mv`s `/home/runner/externals/*` into an `emptyDir` (and no longer mounts that volume).

Default (unset/`false`) is **unchanged** — the externals `emptyDir` is seeded by `fs-init` exactly as today.

## Why

In `kubernetes` / `kubernetes-novolume` mode, `fs-init` copies the full externals tree (~600MB) into an `emptyDir` on **every job pod**. That copy is pure startup latency on every job. Kubernetes [image volumes](https://kubernetes.io/docs/concepts/storage/volumes/#image) let the kubelet mount the runner image's already-present externals directly, so the per-job copy disappears (the image is pulled once per node and cached). In our environment this removed a multi-minute cold-start under burst.

## Safety / gating

- **Opt-in, default off** — zero behaviour change unless the env is set.
- Image volumes need the `ImageVolume` feature gate, **default-on in Kubernetes 1.35+** (beta). On clusters where it's unavailable the API server silently drops the `image:` volume source and the job would start with nothing at `/__e`, so this is deliberately **not** auto-enabled — the operator opts in when they know their cluster supports it. Documented in `packages/k8s/README.md`.

## Implementation

- `utils.ts`: `ENV_EXTERNALS_FROM_IMAGE`, `externalsFromImage()`, `runnerImage()`, `externalsVolume()`; `CONTAINER_VOLUMES` → `containerVolumes()` (the `/__e` mount gains `subPath`+`readOnly` only when enabled).
- `index.ts`: gate the `fs-init` seed commands + externals mount, and use `externalsVolume()` in both `createJobPod` and `createContainerStepPod`.
- `prepare-job.ts` / `run-container-step.ts`: use `containerVolumes()`.

## Testing

- `npm run bootstrap && npm run build-all` — clean (TypeScript compiles; `image:` volume typechecks against `@kubernetes/client-node ^1.3.0`).
- `prettier --check` — clean.
- Manually validated both paths render the expected pod spec (default = `emptyDir` + `fs-init` copy; enabled = `image:` volume, no copy, read-only `/__e` subPath).

Happy to add unit coverage for `containerVolumes()`/`externalsVolume()` if you'd like.